### PR TITLE
Eliminação do prefixo ":" sem o edo.

### DIFF
--- a/core/edo/energy-domain-ontology.ttl
+++ b/core/edo/energy-domain-ontology.ttl
@@ -1,4 +1,3 @@
-@prefix : <https://w3id.org/energy-domain/edo#> .
 @prefix edo: <https://w3id.org/energy-domain/edo#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -65,58 +64,58 @@ skos:prefLabel rdf:type owl:AnnotationProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#DomainAnnotation
-:DomainAnnotation rdf:type owl:AnnotationProperty .
+edo:DomainAnnotation rdf:type owl:AnnotationProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#DomainAuxiliarAnnotation
-:DomainAuxiliarAnnotation rdf:type owl:AnnotationProperty ;
-                          rdfs:subPropertyOf :DomainAnnotation .
+edo:DomainAuxiliarAnnotation rdf:type owl:AnnotationProperty ;
+                          rdfs:subPropertyOf edo:DomainAnnotation .
 
 
 ###  https://w3id.org/energy-domain/edo#DomainEngineeringAnnotation
-:DomainEngineeringAnnotation rdf:type owl:AnnotationProperty ;
-                             rdfs:subPropertyOf :DomainAnnotation .
+edo:DomainEngineeringAnnotation rdf:type owl:AnnotationProperty ;
+                             rdfs:subPropertyOf edo:DomainAnnotation .
 
 
 ###  https://w3id.org/energy-domain/edo#DomainRelationship
-:DomainRelationship rdf:type owl:AnnotationProperty ;
-                    rdfs:subPropertyOf :DomainAnnotation .
+edo:DomainRelationship rdf:type owl:AnnotationProperty ;
+                    rdfs:subPropertyOf edo:DomainAnnotation .
 
 
 ###  https://w3id.org/energy-domain/edo#appliesTo
-:appliesTo rdf:type owl:AnnotationProperty ;
+edo:appliesTo rdf:type owl:AnnotationProperty ;
            rdfs:label "Applies to"@en ,
                       "Se aplica a"@pt-br ;
            skos:definition "Indica que o sujeito se aplica ao predicado"@pt-br ,
                            "Indicates that the subject applies to the object"@en ;
-           rdfs:subPropertyOf :DomainAuxiliarAnnotation .
+           rdfs:subPropertyOf edo:DomainAuxiliarAnnotation .
 
 
 ###  https://w3id.org/energy-domain/edo#createdAtLifecyclePhase
-:createdAtLifecyclePhase rdf:type owl:AnnotationProperty ;
+edo:createdAtLifecyclePhase rdf:type owl:AnnotationProperty ;
                          rdfs:label "Created at lifecycle phase"@en ,
                                     "Criado na fase do ciclo de vida"@pt-br ;
                          skos:definition "Em que fase do ciclo de vida a informação foi criada"@pt-br ,
                                          "In which lifecycle phase the information was created"@en ;
-                         rdfs:subPropertyOf :DomainEngineeringAnnotation .
+                         rdfs:subPropertyOf edo:DomainEngineeringAnnotation .
 
 
 ###  https://w3id.org/energy-domain/edo#defaultValidValues
-:defaultValidValues rdf:type owl:AnnotationProperty ;
-                    rdfs:subPropertyOf :DomainAuxiliarAnnotation .
+edo:defaultValidValues rdf:type owl:AnnotationProperty ;
+                    rdfs:subPropertyOf edo:DomainAuxiliarAnnotation .
 
 
 ###  https://w3id.org/energy-domain/edo#hasAttribute
-:hasAttribute rdf:type owl:AnnotationProperty ;
+edo:hasAttribute rdf:type owl:AnnotationProperty ;
               rdfs:label "Has attribute"@en ,
                          "Possui atributo"@pt-br ;
               skos:definition "Indica atributo(s) que a entidade possui"@pt-br ,
                               "Indicates attribute(s) that the entity has"@en ;
-              rdfs:subPropertyOf :DomainAuxiliarAnnotation .
+              rdfs:subPropertyOf edo:DomainAuxiliarAnnotation .
 
 
 ###  https://w3id.org/energy-domain/edo#hasAttributeCategory
-:hasAttributeCategory rdf:type owl:AnnotationProperty ;
+edo:hasAttributeCategory rdf:type owl:AnnotationProperty ;
                       rdfs:label "has attribute category"@en ,
                                  "tem categoria de atributo"@pt-br ;
                       skos:definition "A categoria técnica do atributo (geométrica, funcional, etc.)"@pt-br ,
@@ -124,7 +123,7 @@ skos:prefLabel rdf:type owl:AnnotationProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#hasAttributeGroup
-:hasAttributeGroup rdf:type owl:AnnotationProperty ;
+edo:hasAttributeGroup rdf:type owl:AnnotationProperty ;
                    rdfs:label "has attribute group"@en ,
                               "tem grupo de atributo"@pt-br ;
                    skos:definition "Indica que o atributo tem um agrupamento especial para fins de organização"@pt-br ,
@@ -132,7 +131,7 @@ skos:prefLabel rdf:type owl:AnnotationProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#hasAttributeScope
-:hasAttributeScope rdf:type owl:AnnotationProperty ;
+edo:hasAttributeScope rdf:type owl:AnnotationProperty ;
                    rdfs:label "has attribute scope"@en ,
                               "tem escopo de atributo"@pt-br ;
                    skos:definition "Classifica se o atributo se aplica ao tipo de equipamento, instância ou lote"@pt-br ,
@@ -140,25 +139,25 @@ skos:prefLabel rdf:type owl:AnnotationProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#hasDiscipline
-:hasDiscipline rdf:type owl:AnnotationProperty ;
+edo:hasDiscipline rdf:type owl:AnnotationProperty ;
                rdfs:label "Has Discipline"@en ,
                           "Pertence a uma disciplina técnica"@pt-br ;
                skos:definition "Associa a entidade a uma disciplina técnica"@pt-br ,
                                "Belongs to a technical discipline"@en ;
-               rdfs:subPropertyOf :DomainEngineeringAnnotation .
+               rdfs:subPropertyOf edo:DomainEngineeringAnnotation .
 
 
 ###  https://w3id.org/energy-domain/edo#hasDomain
-:hasDomain rdf:type owl:AnnotationProperty ;
+edo:hasDomain rdf:type owl:AnnotationProperty ;
            rdfs:label "Has Domain"@en ,
                       "Pertence a um domínio"@pt-br ;
            skos:definition "Associa a entidade a um ou mais domínios"@pt-br ,
                            "Belongs to one or more domains"@en ;
-           rdfs:subPropertyOf :DomainEngineeringAnnotation .
+           rdfs:subPropertyOf edo:DomainEngineeringAnnotation .
 
 
 ###  https://w3id.org/energy-domain/edo#hasLifecycleCreationPhase
-:hasLifecycleCreationPhase rdf:type owl:AnnotationProperty ;
+edo:hasLifecycleCreationPhase rdf:type owl:AnnotationProperty ;
                            rdfs:label "has lifecycle creation phase"@en ,
                                       "tem fase de criação no ciclo de vida"@pt-br ;
                            skos:definition "A fase do ciclo de vida quando o valor do atributo é criado"@pt-br ,
@@ -166,7 +165,7 @@ skos:prefLabel rdf:type owl:AnnotationProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#hasLifecycleUsagePhase
-:hasLifecycleUsagePhase rdf:type owl:AnnotationProperty ;
+edo:hasLifecycleUsagePhase rdf:type owl:AnnotationProperty ;
                         rdfs:label "has lifecycle usage phase"@en ,
                                    "tem fase de uso no ciclo de vida"@pt-br ;
                         skos:definition "A(s) fase(s) do ciclo de vida quando o valor do atributo é utilizado"@pt-br ,
@@ -174,80 +173,80 @@ skos:prefLabel rdf:type owl:AnnotationProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#hasLocationType
-:hasLocationType rdf:type owl:AnnotationProperty ;
+edo:hasLocationType rdf:type owl:AnnotationProperty ;
                  rdfs:label "Has Location Type"@en ,
                             "Pertence a um tipo de locação"@pt-br ;
                  skos:definition "Associa a entidade a um tipo de locação"@pt-br ,
                                  "Belongs to one or more Location Types"@en ;
-                 rdfs:subPropertyOf :DomainEngineeringAnnotation .
+                 rdfs:subPropertyOf edo:DomainEngineeringAnnotation .
 
 
 ###  https://w3id.org/energy-domain/edo#hasSubDomain
-:hasSubDomain rdf:type owl:AnnotationProperty ;
+edo:hasSubDomain rdf:type owl:AnnotationProperty ;
               rdfs:label "Has SubDomain"@en ,
                          "Pertence a um subdomínio"@pt-br ;
               skos:definition "Associa a entidade a um ou mais subdomínios"@pt-br ,
                               "Belongs to one or more subdomains"@en ;
-              rdfs:subPropertyOf :DomainEngineeringAnnotation .
+              rdfs:subPropertyOf edo:DomainEngineeringAnnotation .
 
 
 ###  https://w3id.org/energy-domain/edo#hasTypedValue
-:hasTypedValue rdf:type owl:AnnotationProperty ;
+edo:hasTypedValue rdf:type owl:AnnotationProperty ;
                rdfs:label "Has Typed Value"@en ,
                           "Possui tipo de valor"@pt-br ;
                skos:definition "Indica que a entidade tem um valor como número real, inteiro, texto, booleano e etc."@pt-br ,
                                "Indicates that the entity has a typed value, lik float, string, boolean, integer, etc."@en ;
-               rdfs:subPropertyOf :DomainAuxiliarAnnotation .
+               rdfs:subPropertyOf edo:DomainAuxiliarAnnotation .
 
 
 ###  https://w3id.org/energy-domain/edo#hasValueCardinality
-:hasValueCardinality rdf:type owl:AnnotationProperty ;
+edo:hasValueCardinality rdf:type owl:AnnotationProperty ;
                      rdfs:label "Has Value Cardinality"@en ,
                                 "Possui cardinalidade de valor"@pt-br ;
                      skos:definition "Indica a quantidade de valores que a entidade possui"@pt-br ,
                                      "Indicates the quantity of values the entity support"@en ;
-                     rdfs:subPropertyOf :DomainAuxiliarAnnotation .
+                     rdfs:subPropertyOf edo:DomainAuxiliarAnnotation .
 
 
 ###  https://w3id.org/energy-domain/edo#ifc_equivalentClass
-:ifc_equivalentClass rdf:type owl:AnnotationProperty ;
+edo:ifc_equivalentClass rdf:type owl:AnnotationProperty ;
                      rdfs:label "Classe IFC equivalente"@pt-br ,
                                 "IFC equivalent Class"@en ;
                      skos:definition "Classe IFC equivalente"@pt-br ,
                                      "IFC equivalent class"@en ;
-                     rdfs:subPropertyOf :DomainEngineeringAnnotation .
+                     rdfs:subPropertyOf edo:DomainEngineeringAnnotation .
 
 
 ###  https://w3id.org/energy-domain/edo#ifc_objectType
-:ifc_objectType rdf:type owl:AnnotationProperty ;
+edo:ifc_objectType rdf:type owl:AnnotationProperty ;
                 rdfs:label "IFC ObjectType"@en ,
                            "ObjectType IFC"@pt-br ;
                 skos:definition "Object Type for IFC class customization"@en ,
                                 "Object Type para a customização de classes IFC"@pt-br ;
-                rdfs:subPropertyOf :DomainEngineeringAnnotation .
+                rdfs:subPropertyOf edo:DomainEngineeringAnnotation .
 
 
 ###  https://w3id.org/energy-domain/edo#ifc_predefinedType
-:ifc_predefinedType rdf:type owl:AnnotationProperty ;
+edo:ifc_predefinedType rdf:type owl:AnnotationProperty ;
                     rdfs:label "IFC PredefinedType"@en ,
                                "PredefinedType IFC"@pt-br ;
                     skos:definition "Predefined Type for IFC class customization"@en ,
                                     "Predefined Type para a customização de classes IFC"@pt-br ;
-                    rdfs:subPropertyOf :DomainEngineeringAnnotation .
+                    rdfs:subPropertyOf edo:DomainEngineeringAnnotation .
 
 
 ###  https://w3id.org/energy-domain/edo#specifiValidValues
-:specifiValidValues rdf:type owl:AnnotationProperty ;
-                    rdfs:subPropertyOf :DomainAuxiliarAnnotation .
+edo:specifiValidValues rdf:type owl:AnnotationProperty ;
+                    rdfs:subPropertyOf edo:DomainAuxiliarAnnotation .
 
 
 ###  https://w3id.org/energy-domain/edo#validValues
-:validValues rdf:type owl:AnnotationProperty ;
+edo:validValues rdf:type owl:AnnotationProperty ;
              rdfs:label "Valid Values"@en ,
                         "Valores Válidos"@pt-br ;
              skos:definition "List of Valid Values for the Attribute"@en ,
                              "Lista de valores válidos para o atributo"@pt-br ;
-             rdfs:subPropertyOf :DomainAuxiliarAnnotation .
+             rdfs:subPropertyOf edo:DomainAuxiliarAnnotation .
 
 
 #################################################################
@@ -267,7 +266,7 @@ xsd:time rdf:type rdfs:Datatype .
 #################################################################
 
 ###  https://w3id.org/energy-domain/edo#DomainAuxiliarProperty
-:DomainAuxiliarProperty rdf:type owl:ObjectProperty .
+edo:DomainAuxiliarProperty rdf:type owl:ObjectProperty .
 
 
 #################################################################
@@ -283,58 +282,58 @@ rdf:value rdf:type owl:DatatypeProperty .
 #################################################################
 
 ###  https://w3id.org/energy-domain/edo#AbsoluteInsidePressure
-:AbsoluteInsidePressure rdf:type owl:Class ;
-                        rdfs:subClassOf :BendingStiffnessAttribute ;
+edo:AbsoluteInsidePressure rdf:type owl:Class ;
+                        rdfs:subClassOf edo:BendingStiffnessAttribute ;
                         dcterms:accessRights "PUBLIC" ;
                         dcterms:identifier "AbsoluteInsidePressure" ;
                         skos:definition "Represents the absolute internal pressure exerted within a component or system. This property is crucial for evaluating the structural integrity and performance, ensuring that the system can withstand the specified pressure without failure, particularly in subsea environments where pressure management is critical."@en ;
                         skos:prefLabel "Absolute Inside Pressure"@en ,
                                        "Pressão Absoluta Interna"@pt-br ;
-                        :hasAttributeScope :TypeLevelAttribute ;
-                        :hasTypedValue :floatValue ;
-                        :hasValueCardinality :singleValue .
+                        edo:hasAttributeScope edo:TypeLevelAttribute ;
+                        edo:hasTypedValue edo:floatValue ;
+                        edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#AbsoluteOutsidePressure
-:AbsoluteOutsidePressure rdf:type owl:Class ;
-                         rdfs:subClassOf :BendingStiffnessAttribute ;
+edo:AbsoluteOutsidePressure rdf:type owl:Class ;
+                         rdfs:subClassOf edo:BendingStiffnessAttribute ;
                          dcterms:accessRights "PUBLIC" ;
                          dcterms:identifier "AbsoluteOutsidePressure" ;
                          skos:definition "Represents the absolute external pressure exerted on a component or system. This property is essential for evaluating how the system withstands pressure from its surrounding environment, particularly in subsea applications where external pressure can be significantly higher and impact the structural integrity of the system."@en ;
                          skos:prefLabel "Absolute Outside Pressure"@en ,
                                         "Pressão Absoluta Externa"@pt-br ;
-                         :hasAttributeScope :TypeLevelAttribute ;
-                         :hasTypedValue :floatValue ;
-                         :hasValueCardinality :singleValue .
+                         edo:hasAttributeScope edo:TypeLevelAttribute ;
+                         edo:hasTypedValue edo:floatValue ;
+                         edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#Accessory
-:Accessory rdf:type owl:Class ;
-           rdfs:subClassOf :CompactObject ;
+edo:Accessory rdf:type owl:Class ;
+           rdfs:subClassOf edo:CompactObject ;
            dcterms:identifier "Accessory" .
 
 
 ###  https://w3id.org/energy-domain/edo#ActuatedEquipment
-:ActuatedEquipment rdf:type owl:Class ;
-                   rdfs:subClassOf :SubseaEquipment ;
+edo:ActuatedEquipment rdf:type owl:Class ;
+                   rdfs:subClassOf edo:SubseaEquipment ;
                    dcterms:identifier "ActuatedEquipment" .
 
 
 ###  https://w3id.org/energy-domain/edo#ActuatedValve
-:ActuatedValve rdf:type owl:Class ;
-               rdfs:subClassOf :Valve ;
+edo:ActuatedValve rdf:type owl:Class ;
+               rdfs:subClassOf edo:Valve ;
                dcterms:identifier "ActuatedValve" .
 
 
 ###  https://w3id.org/energy-domain/edo#Anchor
-:Anchor rdf:type owl:Class ;
-        rdfs:subClassOf :Structure ;
+edo:Anchor rdf:type owl:Class ;
+        rdfs:subClassOf edo:Structure ;
         dcterms:identifier "Anchor" .
 
 
 ###  https://w3id.org/energy-domain/edo#AnchoringCollar
-:AnchoringCollar rdf:type owl:Class ;
-                 rdfs:subClassOf :SplitCollar ;
+edo:AnchoringCollar rdf:type owl:Class ;
+                 rdfs:subClassOf edo:SplitCollar ;
                  dcterms:identifier "AnchoringCollar" ;
                  skos:altLabel "Anchor Clamp"@en ,
                                "Anchoring Device"@en ,
@@ -344,23 +343,23 @@ rdf:value rdf:type owl:DatatypeProperty .
                                  "Um dispositivo mecânico usado para estabilizar e fixar dutos flexíveis ou risers a estruturas fixas em aplicações submarinas, além de dar suporte aos sistemas umbilicais. Ao se prender às camadas externas do tubo, evita movimentos indesejados durante a instalação e operação, ajudando a manter o alinhamento e a integridade sob tensão ou compressão."@pt-br ;
                  skos:prefLabel "Anchoring Collar"@en ,
                                 "Colar de Ancoragem"@pt-br ;
-                 :hasAttribute :AnodeCollarsAxialSpacing ,
-                               :AnodeCollarsQuantity ,
-                               :ClampInternalDiameter ,
-                               :ExternalDiameter ,
-                               :GalvanicMaterial ,
-                               :IndividualAnodeMass ,
-                               :MetallicStrandLength ,
-                               :MetallicStrandSpareQuantity ,
-                               :SafeWorkingLoad ;
-                 :ifc_equivalentClass "IfcPipeFitting" ;
-                 :ifc_objectType "AnchoringCollar" ;
-                 :ifc_predefinedType "USERDEFINED" .
+                 edo:hasAttribute edo:AnodeCollarsAxialSpacing ,
+                               edo:AnodeCollarsQuantity ,
+                               edo:ClampInternalDiameter ,
+                               edo:ExternalDiameter ,
+                               edo:GalvanicMaterial ,
+                               edo:IndividualAnodeMass ,
+                               edo:MetallicStrandLength ,
+                               edo:MetallicStrandSpareQuantity ,
+                               edo:SafeWorkingLoad ;
+                 edo:ifc_equivalentClass "IfcPipeFitting" ;
+                 edo:ifc_objectType "AnchoringCollar" ;
+                 edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#AnodeCollarSet
-:AnodeCollarSet rdf:type owl:Class ;
-                rdfs:subClassOf :SplitCollar ;
+edo:AnodeCollarSet rdf:type owl:Class ;
+                rdfs:subClassOf edo:SplitCollar ;
                 dcterms:identifier "AnodeCollarSet" ;
                 skos:altLabel "Anode Bracket"@en ,
                               "Anode Clamp"@en ,
@@ -369,73 +368,73 @@ rdf:value rdf:type owl:DatatypeProperty .
                                 "Sacrificial anode collar set used for corrosion protection in subsea environments. It is designed to attach around pipes or risers and undergo controlled corrosion, thus protecting the metallic structures from rust and degradation. Typically made from zinc or aluminum, it ensures the longevity of subsea equipment by sacrificing itself to prevent corrosion on critical infrastructure."@en ;
                 skos:prefLabel "Anode Collar Set"@en ,
                                "Conjunto de Colares de Anodo"@pt-br ;
-                :ifc_equivalentClass "IfcPipeFitting" ;
-                :ifc_objectType "AnodeCollarSet" ;
-                :ifc_predefinedType "USERDEFINED" .
+                edo:ifc_equivalentClass "IfcPipeFitting" ;
+                edo:ifc_objectType "AnodeCollarSet" ;
+                edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#AnodeCollarsAxialSpacing
-:AnodeCollarsAxialSpacing rdf:type owl:Class ;
-                          rdfs:subClassOf :DomainAttribute ;
+edo:AnodeCollarsAxialSpacing rdf:type owl:Class ;
+                          rdfs:subClassOf edo:DomainAttribute ;
                           dcterms:accessRights "PUBLIC" ;
                           dcterms:identifier "AnodeCollarsAxialSpacing" ;
                           skos:definition "Axial distance between each individual collar."@en ;
                           skos:prefLabel "Anode Collars Axial Spacing"@en ,
                                          "Espaçamento Axial entre os Colares de Anodo"@pt-br ;
-                          :hasAttributeScope :TypeLevelAttribute ;
-                          :hasTypedValue :floatValue ;
-                          :hasValueCardinality :singleValue .
+                          edo:hasAttributeScope edo:TypeLevelAttribute ;
+                          edo:hasTypedValue edo:floatValue ;
+                          edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#AnodeCollarsQuantity
-:AnodeCollarsQuantity rdf:type owl:Class ;
-                      rdfs:subClassOf :DomainAttribute ;
+edo:AnodeCollarsQuantity rdf:type owl:Class ;
+                      rdfs:subClassOf edo:DomainAttribute ;
                       dcterms:accessRights "PUBLIC" ;
                       dcterms:identifier "AnodeCollarsQuantity" ;
                       skos:definition "The total number of anode collars to provide cathodic protection against corrosion."@en ;
                       skos:prefLabel "Anode Collars Quantity"@en ,
                                      "Quantidade de Colares de Anodo"@pt-br ;
-                      :hasAttributeScope :TypeLevelAttribute ;
-                      :hasTypedValue :intValue ;
-                      :hasValueCardinality :singleValue .
+                      edo:hasAttributeScope edo:TypeLevelAttribute ;
+                      edo:hasTypedValue edo:intValue ;
+                      edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#AnodeSled
-:AnodeSled rdf:type owl:Class ;
-           rdfs:subClassOf :Structure ;
+edo:AnodeSled rdf:type owl:Class ;
+           rdfs:subClassOf edo:Structure ;
            dcterms:identifier "AnodeSled" .
 
 
 ###  https://w3id.org/energy-domain/edo#AntiCollapseSheath
-:AntiCollapseSheath rdf:type owl:Class ;
-                    rdfs:subClassOf :SolidLayer ;
+edo:AntiCollapseSheath rdf:type owl:Class ;
+                    rdfs:subClassOf edo:SolidLayer ;
                     dcterms:identifier "AntiCollapseSheath" ;
                     skos:definition "Camada de reforço em dutos flexíveis submarinos usados na exploração de petróleo e gás, projetada para evitar o colapso do duto sob altas pressões externas, como as encontradas em ambientes de águas profundas. Sua função principal é fornecer suporte estrutural contra forças externas que poderiam comprimir ou deformar o duto, especialmente durante situações em que a pressão interna é reduzida ou ausente, como quando o duto está vazio. Normalmente feita de materiais metálicos ou poliméricos de alta resistência, a Capa Anti-Colapso garante a integridade do duto flexível em condições extremas."@pt-br ,
                                     "Reinforcement layer in subsea flexible pipes used in oil and gas exploration, designed to prevent the collapse of the pipe under high external pressure conditions, such as those encountered in deepwater environments. Its primary role is to provide structural support against external forces that could compress or deform the pipe, particularly during situations where the internal pressure is reduced or absent, like when the pipe is emptied. Typically made from high-strength metallic or polymeric materials, the Anti Collapse Sheath ensures the integrity of the flexible pipe under extreme conditions."@en ;
                     skos:prefLabel "Anti Collapse Sheath"@en ,
                                    "Capa Anti-Colapso"@pt-br ;
-                    :ifc_equivalentClass "IfcPipeSegment" ;
-                    :ifc_objectType "AntiCollapseSheath" ;
-                    :ifc_predefinedType "USERDEFINED" .
+                    edo:ifc_equivalentClass "IfcPipeSegment" ;
+                    edo:ifc_objectType "AntiCollapseSheath" ;
+                    edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#AntiWearSheath
-:AntiWearSheath rdf:type owl:Class ;
-                rdfs:subClassOf :SolidLayer ;
+edo:AntiWearSheath rdf:type owl:Class ;
+                rdfs:subClassOf edo:SolidLayer ;
                 dcterms:identifier "AntiWearSheath" ;
                 skos:definition "Camada de reforço em dutos flexíveis usados na exploração de petróleo e gás, projetada para proteger o duto do desgaste externo e da abrasão causados pelo contato com o fundo marinho, equipamentos ou outros elementos submarinos. Seu papel principal é fornecer uma barreira protetora durável que protege as camadas subjacentes contra danos mecânicos, aumentando a vida útil do tubo flexível. Geralmente feita de materiais poliméricos resistentes ao desgaste, a Capa Anti-Atrito garante a integridade do duto ao reduzir o risco de danos na superfície em condições operacionais adversas."@pt-br ,
                                 "Reinforcement layer in subsea flexible pipes used in oil and gas exploration, designed to protect the pipe from external wear and abrasion caused by contact with the seabed, equipment, or other subsea elements. Its primary role is to provide a durable protective barrier that shields the underlying layers from mechanical damage, extending the lifespan of the flexible pipe. Typically made from wear-resistant polymeric materials, the Anti Wear Sheath ensures the pipe's integrity by reducing the risk of surface damage under harsh operating conditions."@en ;
                 skos:prefLabel "Anti Wear Sheath"@en ,
                                "Capa Anti-Atrito"@pt-br ;
-                :hasAttribute :TapesQuantity ;
-                :ifc_equivalentClass "IfcPipeSegment" ;
-                :ifc_objectType "AntiWearSheath" ;
-                :ifc_predefinedType "USERDEFINED" .
+                edo:hasAttribute edo:TapesQuantity ;
+                edo:ifc_equivalentClass "IfcPipeSegment" ;
+                edo:ifc_objectType "AntiWearSheath" ;
+                edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#ArchitecturalEngineering
-:ArchitecturalEngineering rdf:type owl:Class ;
-                          rdfs:subClassOf :TechnicalDiscipline ;
+edo:ArchitecturalEngineering rdf:type owl:Class ;
+                          rdfs:subClassOf edo:TechnicalDiscipline ;
                           rdfs:label "Architectural Engineering"@en ,
                                      "Engenharia Arquitetônica"@pt-br ;
                           skos:definition "Disciplina de engenharia focada no projeto de edifícios, construção e integração de sistemas."@pt-br ,
@@ -443,17 +442,17 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#ArmorPot
-:ArmorPot rdf:type owl:Class ;
-          rdfs:subClassOf :LineTermination ;
+edo:ArmorPot rdf:type owl:Class ;
+          rdfs:subClassOf edo:LineTermination ;
           dcterms:identifier "ArmorPot" ;
-          :ifc_equivalentClass "IfcPipeFitting" ;
-          :ifc_objectType "ArmorPot" ;
-          :ifc_predefinedType "USERDEFINED" .
+          edo:ifc_equivalentClass "IfcPipeFitting" ;
+          edo:ifc_objectType "ArmorPot" ;
+          edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#ArmourLayer
-:ArmourLayer rdf:type owl:Class ;
-             rdfs:subClassOf :WoundLayer ;
+edo:ArmourLayer rdf:type owl:Class ;
+             rdfs:subClassOf edo:WoundLayer ;
              dcterms:identifier "ArmourLayer" ;
              skos:definition "A reinforcement layer in subsea flexible pipes used in oil and gas exploration, designed to provide mechanical strength and protection against external forces, such as pressure and movement. It ensures structural integrity by preventing deformation and failure during operation. Typically made from high-strength metal wires, like carbon steel or stainless steel, the Armor Layer enhances the pipe's durability in harsh underwater conditions."@en ;
              skos:prefLabel "Armour Layer"@en ,
@@ -461,50 +460,50 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#AssemblyShouldObeyModelPolarity
-:AssemblyShouldObeyModelPolarity rdf:type owl:Class ;
-                                 rdfs:subClassOf :DomainAttribute ;
+edo:AssemblyShouldObeyModelPolarity rdf:type owl:Class ;
+                                 rdfs:subClassOf edo:DomainAttribute ;
                                  dcterms:accessRights "PUBLIC" ;
                                  dcterms:identifier "AssemblyShouldObeyModelPolarity" ;
                                  skos:definition "If true, the pipe section must be assembled according to the polarity in the model. If false, it can be mounted in any polarity."@en ;
                                  skos:prefLabel "A Montagem Deve Obedecer à Polaridade do Modelo"@pt-br ,
                                                 "Assembly Should Obey Model Polarity"@en ;
-                                 :hasAttributeScope :InstanceLevelAttribute ;
-                                 :hasTypedValue :booleanValue ;
-                                 :hasValueCardinality :singleValue .
+                                 edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                 edo:hasTypedValue edo:booleanValue ;
+                                 edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#AssemblyTorque
-:AssemblyTorque rdf:type owl:Class ;
-                rdfs:subClassOf :DomainAttribute ;
+edo:AssemblyTorque rdf:type owl:Class ;
+                rdfs:subClassOf edo:DomainAttribute ;
                 dcterms:accessRights "PUBLIC" ;
                 dcterms:identifier "AssemblyTorque" ;
                 skos:definition "Specifies the torque applied during assembly, ensuring proper tightening for secure connections. This value is critical for maintaining the structural integrity and reliability of the connection under operational loads."@en ;
                 skos:prefLabel "Assembly Torque"@en ,
                                "Torque de montagem"@pt-br ;
-                :hasAttributeScope :InstanceLevelAttribute ;
-                :hasTypedValue :floatValue ;
-                :hasValueCardinality :singleValue .
+                edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                edo:hasTypedValue edo:floatValue ;
+                edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#Asset
-:Asset rdf:type owl:Class ;
-       rdfs:subClassOf :DomainElement ;
+edo:Asset rdf:type owl:Class ;
+       rdfs:subClassOf edo:DomainElement ;
        dcterms:identifier "Asset" ;
        skos:definition "An asset refers to valuable resources such as platforms, equipment, pipelines, and processing facilities crucial for production and transportation. These assets are managed to optimize performance, ensure safety, and maximize operational efficiency throughout their lifecycle."@en ;
        skos:prefLabel "Asset"@en ,
                       "Ativo"@pt-br ;
-       :hasAttribute :IsSpare ,
-                     :SerialNumber .
+       edo:hasAttribute edo:IsSpare ,
+                     edo:SerialNumber .
 
 
 ###  https://w3id.org/energy-domain/edo#AttributeClassification
-:AttributeClassification rdf:type owl:Class ;
-                         rdfs:subClassOf :DomainClassification .
+edo:AttributeClassification rdf:type owl:Class ;
+                         rdfs:subClassOf edo:DomainClassification .
 
 
 ###  https://w3id.org/energy-domain/edo#AttributeDomainCategory
-:AttributeDomainCategory rdf:type owl:Class ;
-                         rdfs:subClassOf :AttributeClassification ;
+edo:AttributeDomainCategory rdf:type owl:Class ;
+                         rdfs:subClassOf edo:AttributeClassification ;
                          rdfs:comment "Classifies the nature or domain of the attribute's content."@en ;
                          rdfs:label "Attribute Domain Category"@en ,
                                     "Categoria de Domínio do Atributo"@pt-br ;
@@ -513,8 +512,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#AttributeScope
-:AttributeScope rdf:type owl:Class ;
-                rdfs:subClassOf :AttributeClassification ;
+edo:AttributeScope rdf:type owl:Class ;
+                rdfs:subClassOf edo:AttributeClassification ;
                 rdfs:comment "Defines whether the attribute applies to all instances of a type or to a specific instance."@en ;
                 rdfs:label "Attribute Scope"@en ,
                            "Escopo do Atributo"@pt-br ;
@@ -523,8 +522,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#AutomationControlEngineering
-:AutomationControlEngineering rdf:type owl:Class ;
-                              rdfs:subClassOf :TechnicalDiscipline ;
+edo:AutomationControlEngineering rdf:type owl:Class ;
+                              rdfs:subClassOf edo:TechnicalDiscipline ;
                               rdfs:label "Automation & Control Engineering"@en ,
                                          "Engenharia de Automação e Controle"@pt-br ;
                               skos:definition "Disciplina de engenharia focada em sistemas de controle automatizado e automação de processos."@pt-br ,
@@ -532,48 +531,48 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#AuxiliaryModule
-:AuxiliaryModule rdf:type owl:Class ;
-                 rdfs:subClassOf :SubseaEquipment ;
+edo:AuxiliaryModule rdf:type owl:Class ;
+                 rdfs:subClassOf edo:SubseaEquipment ;
                  dcterms:identifier "AuxiliaryModule" .
 
 
 ###  https://w3id.org/energy-domain/edo#AxialStiffnessUnderCompressionAtSeaLevel
-:AxialStiffnessUnderCompressionAtSeaLevel rdf:type owl:Class ;
-                                          rdfs:subClassOf :DomainAttribute ;
+edo:AxialStiffnessUnderCompressionAtSeaLevel rdf:type owl:Class ;
+                                          rdfs:subClassOf edo:DomainAttribute ;
                                           dcterms:accessRights "PUBLIC" ;
                                           dcterms:identifier "AxialStiffnessUnderCompressionAtSeaLevel" ;
                                           skos:definition "Represents the resistance of a component or system to axial deformation under compression when measured at sea level. This property is essential for understanding how the structure behaves under compressive loads, ensuring that it can maintain stability and structural integrity."@en ,
                                                           "Rigidez axial (EA) duto comprimido, 20°C e pressão atmosferica (dentro e fora)"@pt-br ;
                                           skos:prefLabel "Axial Stiffness Under Compression At Sea Level"@en ,
                                                          "Rigidez Axial sob Compressão ao Nível do Mar"@pt-br ;
-                                          :hasAttributeScope :TypeLevelAttribute ;
-                                          :hasTypedValue :floatValue ;
-                                          :hasValueCardinality :singleValue .
+                                          edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                          edo:hasTypedValue edo:floatValue ;
+                                          edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#AxialStiffnessUnderTensionAtSeaLevel
-:AxialStiffnessUnderTensionAtSeaLevel rdf:type owl:Class ;
-                                      rdfs:subClassOf :DomainAttribute ;
+edo:AxialStiffnessUnderTensionAtSeaLevel rdf:type owl:Class ;
+                                      rdfs:subClassOf edo:DomainAttribute ;
                                       dcterms:accessRights "PUBLIC" ;
                                       dcterms:identifier "AxialStiffnessUnderTensionAtSeaLevel" ;
                                       skos:definition "Represents the resistance of a component or system to axial deformation under tension when measured at sea level. This property is crucial for evaluating how the structure performs under tensile loads, ensuring it can withstand stretching forces while maintaining its integrity."@en ,
                                                       "Rigidez axial (EA) duto tracionado, 20°C e pressão atmosferica (dentro e fora)"@pt-br ;
                                       skos:prefLabel "Axial Stiffness Under Tension At Sea Level"@en ,
                                                      "Rigidez Axial sob Tração ao Nível do Mar"@pt-br ;
-                                      :hasAttributeScope :TypeLevelAttribute ;
-                                      :hasTypedValue :floatValue ;
-                                      :hasValueCardinality :singleValue .
+                                      edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                      edo:hasTypedValue edo:floatValue ;
+                                      edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#BOP
-:BOP rdf:type owl:Class ;
-     rdfs:subClassOf :PressureEquipment ;
+edo:BOP rdf:type owl:Class ;
+     rdfs:subClassOf edo:PressureEquipment ;
      dcterms:identifier "BOP" .
 
 
 ###  https://w3id.org/energy-domain/edo#BasicDesign
-:BasicDesign rdf:type owl:Class ;
-             rdfs:subClassOf :LifecyclePhase ;
+edo:BasicDesign rdf:type owl:Class ;
+             rdfs:subClassOf edo:LifecyclePhase ;
              rdfs:label "Basic Design"@en ,
                         "Projeto Básico"@pt-br ;
              skos:definition "Fase onde são desenvolvidas especificações gerais de engenharia, layouts e listas de equipamentos principais."@pt-br ,
@@ -581,22 +580,22 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#BasicProjectRevision
-:BasicProjectRevision rdf:type owl:Class ;
-                      rdfs:subClassOf :DomainAttribute ;
+edo:BasicProjectRevision rdf:type owl:Class ;
+                      rdfs:subClassOf edo:DomainAttribute ;
                       dcterms:accessRights "PUBLIC" ;
                       dcterms:identifier "BasicProjectRevision" ;
                       skos:definition "Numeric value incremented with each new submission of the project (e.g., 0000, 0001, 0002, etc.), recorded as text. This value tracks revisions and ensures clarity in version control throughout the project lifecycle, allowing stakeholders to reference the most current or previous versions as needed."@en ,
                                       "Valor numérico incrementado a cada novo envio (0000, 0001, 0002 e etc.) como texto"@pt-br ;
                       skos:prefLabel "Basic Project Revision"@en ,
                                      "Revisão do Projeto Básico"@pt-br ;
-                      :hasAttributeScope :InstanceLevelAttribute ;
-                      :hasTypedValue :stringValue ;
-                      :hasValueCardinality :singleValue .
+                      edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                      edo:hasTypedValue edo:stringValue ;
+                      edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#BatchLevelAttribute
-:BatchLevelAttribute rdf:type owl:Class ;
-                     rdfs:subClassOf :AttributeScope ;
+edo:BatchLevelAttribute rdf:type owl:Class ;
+                     rdfs:subClassOf edo:AttributeScope ;
                      rdfs:comment "Attribute common to a batch of equipment instances."@en ;
                      rdfs:label "Atributo de Lote"@pt-br ,
                                 "Batch Attribute"@en ;
@@ -605,65 +604,65 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#BendMomentVsShearForceAttribute
-:BendMomentVsShearForceAttribute rdf:type owl:Class ;
-                                 rdfs:subClassOf :DomainAttribute ;
+edo:BendMomentVsShearForceAttribute rdf:type owl:Class ;
+                                 rdfs:subClassOf edo:DomainAttribute ;
                                  rdfs:label "Bending Moment Versus Shear Force Attribute"@en .
 
 
 ###  https://w3id.org/energy-domain/edo#BendMomentVsShearForceTableColumn
-:BendMomentVsShearForceTableColumn rdf:type owl:Class ;
-                                   rdfs:subClassOf :BendMomentVsShearForceAttribute ;
+edo:BendMomentVsShearForceTableColumn rdf:type owl:Class ;
+                                   rdfs:subClassOf edo:BendMomentVsShearForceAttribute ;
                                    dcterms:accessRights "PUBLIC" ;
                                    dcterms:identifier "BendMomentVsShearForceTable" ;
                                    skos:definition "Provides data on the relationship between bending moment and shear force, used to evaluate how the structure behaves under combined loading conditions. This information is critical for determining the structural integrity and performance under different operational stresses."@en ;
                                    skos:prefLabel "Bending moment vs Shear Force Table"@en ,
                                                   "Tabela de Momento de Curvatura em Função da Força Cisalhante"@pt-br ;
-                                   :hasAttributeScope :TypeLevelAttribute .
+                                   edo:hasAttributeScope edo:TypeLevelAttribute .
 
 
 ###  https://w3id.org/energy-domain/edo#BendMomentVsShearForceTable_BendingMoment
-:BendMomentVsShearForceTable_BendingMoment rdf:type owl:Class ;
-                                           rdfs:subClassOf :BendMomentVsShearForceTableColumn ;
+edo:BendMomentVsShearForceTable_BendingMoment rdf:type owl:Class ;
+                                           rdfs:subClassOf edo:BendMomentVsShearForceTableColumn ;
                                            dcterms:accessRights "PUBLIC" ;
                                            dcterms:identifier "BendMomentVsShearForceTable_BendingMoment" ;
                                            skos:definition "Represents the moment generated by a force causing the component or system to bend around an axis. This property is critical for assessing the structure's ability to resist bending under operational loads, ensuring it maintains its shape and structural integrity."@en ;
                                            skos:prefLabel "Bending Moment"@en ,
                                                           "Momento de flexão"@pt-br ;
-                                           :hasAttributeScope :TypeLevelAttribute ;
-                                           :hasTypedValue :floatValue ;
-                                           :hasValueCardinality :multiValue .
+                                           edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                           edo:hasTypedValue edo:floatValue ;
+                                           edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#BendMomentVsShearForceTable_Condition
-:BendMomentVsShearForceTable_Condition rdf:type owl:Class ;
-                                       rdfs:subClassOf :BendMomentVsShearForceAttribute ;
+edo:BendMomentVsShearForceTable_Condition rdf:type owl:Class ;
+                                       rdfs:subClassOf edo:BendMomentVsShearForceAttribute ;
                                        dcterms:accessRights "PUBLIC" ;
                                        dcterms:identifier "BendMomentVsShearForceTable_Condition" ;
                                        skos:definition "Curve data flexible pipe condition."@en ;
                                        skos:prefLabel "Condition"@en ,
                                                       "Condição do flexível para os dados da curva"@pt-br ;
-                                       :hasAttributeScope :TypeLevelAttribute ;
-                                       :hasTypedValue :stringValue ;
-                                       :hasValueCardinality :singleValue .
+                                       edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                       edo:hasTypedValue edo:stringValue ;
+                                       edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#BendMomentVsShearForceTable_ShearForce
-:BendMomentVsShearForceTable_ShearForce rdf:type owl:Class ;
-                                        rdfs:subClassOf :BendMomentVsShearForceTableColumn ;
+edo:BendMomentVsShearForceTable_ShearForce rdf:type owl:Class ;
+                                        rdfs:subClassOf edo:BendMomentVsShearForceTableColumn ;
                                         dcterms:accessRights "PUBLIC" ;
                                         dcterms:identifier "BendMomentVsShearForceTable_ShearForce" ;
                                         skos:definition "Força de cisalhamento (Obrigatório incluir o valor para força = 0)"@pt-br ,
                                                         "Represents the force applied parallel to the surface of a material or component, causing it to experience shear stress. This property is essential for evaluating the material's ability to resist sliding or deformation when subjected to external forces."@en ;
                                         skos:prefLabel "Força de Cisalhamento"@pt-br ,
                                                        "Shear Force"@en ;
-                                        :hasAttributeScope :TypeLevelAttribute ;
-                                        :hasTypedValue :floatValue ;
-                                        :hasValueCardinality :multiValue .
+                                        edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                        edo:hasTypedValue edo:floatValue ;
+                                        edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#BendRestrictor
-:BendRestrictor rdf:type owl:Class ;
-                rdfs:subClassOf :LineAncillary ;
+edo:BendRestrictor rdf:type owl:Class ;
+                rdfs:subClassOf edo:LineAncillary ;
                 dcterms:identifier "BendRestrictor" ;
                 skos:altLabel "Bend Limiter"@en ,
                               "Bending Restrictor"@en ,
@@ -672,17 +671,17 @@ rdf:value rdf:type owl:DatatypeProperty .
                                 "Dispositivo usado em dutos flexíveis para limitar o raio de curvatura e evitar curvaturas excessivas que poderiam danificar o duto. Normalmente instalado perto de áreas críticas, como conectores ou acessórios finais, onde curvaturas excessivas poderiam comprometer a integridade estrutural do duto. O Restritor de Curvatura consiste em múltiplos segmentos interligados que permitem flexibilidade até um certo raio, além do qual os segmentos se bloqueiam para impedir mais curvaturas, protegendo o duto contra deformações ou falhas em ambientes submarinos adversos."@pt-br ;
                 skos:prefLabel "Bend Restrictor"@en ,
                                "Restritor de Curvatura"@pt-br ;
-                :hasAttribute :BendMomentVsShearForceTable ,
-                              :BendMomentVsShearForceTable_BendingMoment ,
-                              :BendMomentVsShearForceTable_Condition ,
-                              :BendMomentVsShearForceTable_ShearForce ;
-                :ifc_equivalentClass "IfcPipeFitting" ;
-                :ifc_objectType "BendRestrictor" .
+                edo:hasAttribute edo:BendMomentVsShearForceTable ,
+                              edo:BendMomentVsShearForceTable_BendingMoment ,
+                              edo:BendMomentVsShearForceTable_Condition ,
+                              edo:BendMomentVsShearForceTable_ShearForce ;
+                edo:ifc_equivalentClass "IfcPipeFitting" ;
+                edo:ifc_objectType "BendRestrictor" .
 
 
 ###  https://w3id.org/energy-domain/edo#BendStiffener
-:BendStiffener rdf:type owl:Class ;
-               rdfs:subClassOf :LineAncillary ;
+edo:BendStiffener rdf:type owl:Class ;
+               rdfs:subClassOf edo:LineAncillary ;
                dcterms:identifier "BendStiffener" ;
                skos:definition "Device used in subsea flexible pipes to provide gradual stiffness transition between the flexible pipe and a fixed structure, preventing excessive bending at critical areas such as terminations or connectors. The Bend Stiffener is designed to manage stress concentration by stiffening the pipe over a defined length, reducing the risk of damage due to repeated bending, fatigue, or over-flexing. Typically made from high-strength materials, it ensures the long-term structural integrity of the pipe in dynamic subsea environments."@en ;
                skos:prefLabel "Bend Stiffener"@en ,
@@ -690,45 +689,45 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#BendingMomentTable_BendingMoment
-:BendingMomentTable_BendingMoment rdf:type owl:Class ;
-                                  rdfs:subClassOf :BendingStiffnessTableColumn ;
+edo:BendingMomentTable_BendingMoment rdf:type owl:Class ;
+                                  rdfs:subClassOf edo:BendingStiffnessTableColumn ;
                                   dcterms:accessRights "PUBLIC" ;
                                   dcterms:identifier "BendingMomentTable_BendingMoment" ;
                                   skos:definition "Represents the moment generated by a force causing the component or system to bend around an axis. This property is critical for assessing the structure's ability to resist bending under operational loads, ensuring it maintains its shape and structural integrity."@en ;
                                   skos:prefLabel "Bending Moment"@en ,
                                                  "Momento de Flexão"@pt-br ;
-                                  :hasAttributeScope :TypeLevelAttribute ;
-                                  :hasTypedValue :floatValue ;
-                                  :hasValueCardinality :multiValue .
+                                  edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                  edo:hasTypedValue edo:floatValue ;
+                                  edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#BendingMomentTable_Curvature
-:BendingMomentTable_Curvature rdf:type owl:Class ;
-                              rdfs:subClassOf :BendingStiffnessTableColumn ;
+edo:BendingMomentTable_Curvature rdf:type owl:Class ;
+                              rdfs:subClassOf edo:BendingStiffnessTableColumn ;
                               dcterms:accessRights "PUBLIC" ;
                               dcterms:identifier "BendingMomentTable_Curvature" ;
                               skos:definition "Represents the degree to which a component or structure bends or curves along its length. This property is important for understanding the flexibility and bending behavior, ensuring that the structure can perform as required under operational conditions without exceeding its design limits."@en ;
                               skos:prefLabel "Curvatura"@pt-br ,
                                              "Curvature"@en ;
-                              :hasAttributeScope :TypeLevelAttribute ;
-                              :hasTypedValue :floatValue ;
-                              :hasValueCardinality :multiValue .
+                              edo:hasAttributeScope edo:TypeLevelAttribute ;
+                              edo:hasTypedValue edo:floatValue ;
+                              edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#BendingStiffnessAttribute
-:BendingStiffnessAttribute rdf:type owl:Class ;
-                           rdfs:subClassOf :DomainAttribute ;
+edo:BendingStiffnessAttribute rdf:type owl:Class ;
+                           rdfs:subClassOf edo:DomainAttribute ;
                            rdfs:label "Bending Stiffness Attribute"@en .
 
 
 ###  https://w3id.org/energy-domain/edo#BendingStiffnessTableColumn
-:BendingStiffnessTableColumn rdf:type owl:Class ;
-                             rdfs:subClassOf :BendingStiffnessAttribute .
+edo:BendingStiffnessTableColumn rdf:type owl:Class ;
+                             rdfs:subClassOf edo:BendingStiffnessAttribute .
 
 
 ###  https://w3id.org/energy-domain/edo#Biomass
-:Biomass rdf:type owl:Class ;
-         rdfs:subClassOf :Renewable ;
+edo:Biomass rdf:type owl:Class ;
+         rdfs:subClassOf edo:Renewable ;
          rdfs:label "Biomass Energy"@en ,
                     "Energia de Biomassa"@pt-br ;
          skos:definition "Energia produzida a partir de materiais orgânicos como madeira, resíduos agrícolas ou lixo."@pt-br ,
@@ -736,43 +735,43 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#BlockValve
-:BlockValve rdf:type owl:Class ;
-            rdfs:subClassOf :ActuatedValve ;
+edo:BlockValve rdf:type owl:Class ;
+            rdfs:subClassOf edo:ActuatedValve ;
             dcterms:identifier "BlockValve" .
 
 
 ###  https://w3id.org/energy-domain/edo#BoltSet
-:BoltSet rdf:type owl:Class ;
-         rdfs:subClassOf :PhysicalConnection ;
+edo:BoltSet rdf:type owl:Class ;
+         rdfs:subClassOf edo:PhysicalConnection ;
          dcterms:identifier "BoltSet" ;
          skos:definition "A collection of bolts and nuts, and washers designed for fastening components in subsea systems. Bolt sets are critical for ensuring structural integrity and are selected based on size, material, and application requirements."@en ;
          skos:prefLabel "Bolt Set"@en ,
                         "Conjunto de Parafusos"@pt-br ;
-         :hasAttribute :AssemblyTorque ,
-                       :FullyThreaded ,
-                       :Lubricant ,
-                       :LubricantFrictionFactor ,
-                       :NominalLength ,
-                       :Quantity ,
-                       :SpareQuantity .
+         edo:hasAttribute edo:AssemblyTorque ,
+                       edo:FullyThreaded ,
+                       edo:Lubricant ,
+                       edo:LubricantFrictionFactor ,
+                       edo:NominalLength ,
+                       edo:Quantity ,
+                       edo:SpareQuantity .
 
 
 ###  https://w3id.org/energy-domain/edo#BoreDiameter
-:BoreDiameter rdf:type owl:Class ;
-              rdfs:subClassOf :DomainAttribute ;
+edo:BoreDiameter rdf:type owl:Class ;
+              rdfs:subClassOf edo:DomainAttribute ;
               dcterms:accessRights "PUBLIC" ;
               dcterms:identifier "BoreDiameter" ;
               skos:definition "Internal diameter that defines the size of the passage through which fluids or gases can flow. This dimension is essential in industrial piping, as it determines flow capacity and impacts pressure and velocity within the system."@en ;
               skos:prefLabel "Bore Diameter"@en ,
                              "Diâmetro do Furo"@pt-br ;
-              :hasAttributeScope :TypeLevelAttribute ;
-              :hasTypedValue :floatValue ;
-              :hasValueCardinality :singleValue .
+              edo:hasAttributeScope edo:TypeLevelAttribute ;
+              edo:hasTypedValue edo:floatValue ;
+              edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#BuoyancyModule
-:BuoyancyModule rdf:type owl:Class ;
-                rdfs:subClassOf :LineAncillary ;
+edo:BuoyancyModule rdf:type owl:Class ;
+                rdfs:subClassOf edo:LineAncillary ;
                 dcterms:identifier "BuoyancyModule" ;
                 skos:altLabel "Buoyancy Element"@en ,
                               "Buoyancy Unit"@en ,
@@ -782,53 +781,53 @@ rdf:value rdf:type owl:DatatypeProperty .
                                 "Dispositivo utilizado em sistemas submarinos para fornecer flutuabilidade controlada a dutos flexíveis, risers ou umbilicais, reduzindo a carga na estrutura e gerenciando a configuração da linha na coluna d'água. O Módulo de Flutuação é tipicamente composto por espuma sintática ou outros materiais de baixa densidade, projetados para suportar altas pressões externas enquanto mantêm suas propriedades de flutuabilidade ao longo do tempo. Ele desempenha um papel fundamental na otimização do desempenho e do posicionamento das linhas subsea, garantindo que mantenham a forma e a profundidade necessárias em condições oceânicas dinâmicas."@pt-br ;
                 skos:prefLabel "Buoyancy Module"@en ,
                                "Módulo de Flutuação"@pt-br ;
-                :hasAttribute :LongTermFloatDensity ,
-                              :LongTermFloatVolume ,
-                              :NominalFloatDensity ,
-                              :NominalFloatVolume ,
-                              :PipeMountPosition ,
-                              :ShortTermFloatDensity ,
-                              :ShortTermFloatVolume ;
-                :ifc_equivalentClass "IfcPipeFitting" ;
-                :ifc_objectType "BuoyancyModule" ;
-                :ifc_predefinedType "USERDEFINED" .
+                edo:hasAttribute edo:LongTermFloatDensity ,
+                              edo:LongTermFloatVolume ,
+                              edo:NominalFloatDensity ,
+                              edo:NominalFloatVolume ,
+                              edo:PipeMountPosition ,
+                              edo:ShortTermFloatDensity ,
+                              edo:ShortTermFloatVolume ;
+                edo:ifc_equivalentClass "IfcPipeFitting" ;
+                edo:ifc_objectType "BuoyancyModule" ;
+                edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#BuoyancyTank
-:BuoyancyTank rdf:type owl:Class ;
-              rdfs:subClassOf :SubseaEquipment ;
+edo:BuoyancyTank rdf:type owl:Class ;
+              rdfs:subClassOf edo:SubseaEquipment ;
               dcterms:identifier "BuoyancyTank" .
 
 
 ###  https://w3id.org/energy-domain/edo#CO2VolumePercentage
-:CO2VolumePercentage rdf:type owl:Class ;
-                     rdfs:subClassOf :DomainAttribute ;
+edo:CO2VolumePercentage rdf:type owl:Class ;
+                     rdfs:subClassOf edo:DomainAttribute ;
                      dcterms:accessRights "PUBLIC" ;
                      dcterms:identifier "CO2VolumePercentage" ;
                      skos:definition "Represents the percentage of carbon dioxide (CO2) in the total volume of the fluid or gas mixture within the pipeline. This value is essential for determining the material selection and design considerations for the flexible subsea pipeline, as CO2 can influence corrosion rates and impact the overall integrity and lifespan of the pipeline."@en ;
                      skos:prefLabel "Carbon Dioxide (CO2) Volume Percentage"@en ,
                                     "Porcentagem de Volume de Dióxido de Carbono (CO2)"@pt-br ;
-                     :hasAttributeScope :InstanceLevelAttribute ;
-                     :hasTypedValue :floatValue ;
-                     :hasValueCardinality :singleValue .
+                     edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                     edo:hasTypedValue edo:floatValue ;
+                     edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#CalculatedAbsoluteBurstPressure
-:CalculatedAbsoluteBurstPressure rdf:type owl:Class ;
-                                 rdfs:subClassOf :DomainAttribute ;
+edo:CalculatedAbsoluteBurstPressure rdf:type owl:Class ;
+                                 rdfs:subClassOf edo:DomainAttribute ;
                                  dcterms:accessRights "PUBLIC" ;
                                  dcterms:identifier "CalculatedAbsoluteBurstPressure" ;
                                  skos:definition "Represents the estimated absolute pressure at which a component or system is expected to fail or rupture. This property is crucial for determining the maximum safe operating pressure, ensuring that the component can withstand internal forces without bursting."@en ;
                                  skos:prefLabel "Calculated Absolute Burst Pressure"@en ,
                                                 "Pressão Absoluta de Ruptura Calculada"@pt-br ;
-                                 :hasAttributeScope :TypeLevelAttribute ;
-                                 :hasTypedValue :floatValue ;
-                                 :hasValueCardinality :singleValue .
+                                 edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                 edo:hasTypedValue edo:floatValue ;
+                                 edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#CalculatedValue
-:CalculatedValue rdf:type owl:Class ;
-                 rdfs:subClassOf :ValueOrigin ;
+edo:CalculatedValue rdf:type owl:Class ;
+                 rdfs:subClassOf edo:ValueOrigin ;
                  rdfs:comment "Derived from other values."@en ;
                  rdfs:label "Calculado"@pt-br ,
                             "Calculated"@en ;
@@ -837,55 +836,55 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#CarcassLayer
-:CarcassLayer rdf:type owl:Class ;
-              rdfs:subClassOf :ArmourLayer ;
+edo:CarcassLayer rdf:type owl:Class ;
+              rdfs:subClassOf edo:ArmourLayer ;
               dcterms:identifier "CarcassLayer" ;
               skos:definition "A reinforcement layer in subsea flexible pipes that provides structural strength and stability. It helps maintain the shape and integrity of the pipe under operational pressure, ensuring the flexibility of the pipe while protecting the internal components. Typically made from metal or polymer materials, it acts as a foundation for the other protective layers."@en ;
               skos:prefLabel "Camada de Carcaça"@pt-br ,
                              "Carcass Layer"@en ;
-              :hasAttribute :MetallicLayerPitch ,
-                            :StressAtDesignPressure .
+              edo:hasAttribute edo:MetallicLayerPitch ,
+                            edo:StressAtDesignPressure .
 
 
 ###  https://w3id.org/energy-domain/edo#CasingHanger
-:CasingHanger rdf:type owl:Class ;
-              rdfs:subClassOf :PressureComponent ;
+edo:CasingHanger rdf:type owl:Class ;
+              rdfs:subClassOf edo:PressureComponent ;
               dcterms:identifier "CasingHanger" .
 
 
 ###  https://w3id.org/energy-domain/edo#ChainSegment
-:ChainSegment rdf:type owl:Class ;
-              rdfs:subClassOf :LinearObject ;
+edo:ChainSegment rdf:type owl:Class ;
+              rdfs:subClassOf edo:LinearObject ;
               dcterms:identifier "ChainSegment" .
 
 
 ###  https://w3id.org/energy-domain/edo#CheckValve
-:CheckValve rdf:type owl:Class ;
-            rdfs:subClassOf :Valve ;
+edo:CheckValve rdf:type owl:Class ;
+            rdfs:subClassOf edo:Valve ;
             dcterms:identifier "CheckValve" .
 
 
 ###  https://w3id.org/energy-domain/edo#ChemicalInjectionUnit
-:ChemicalInjectionUnit rdf:type owl:Class ;
-                       rdfs:subClassOf :TopsideEquipment ;
+edo:ChemicalInjectionUnit rdf:type owl:Class ;
+                       rdfs:subClassOf edo:TopsideEquipment ;
                        dcterms:identifier "ChemicalInjectionUnit" .
 
 
 ###  https://w3id.org/energy-domain/edo#ChokeModule
-:ChokeModule rdf:type owl:Class ;
-             rdfs:subClassOf :FlowControlModule ;
+edo:ChokeModule rdf:type owl:Class ;
+             rdfs:subClassOf edo:FlowControlModule ;
              dcterms:identifier "ChokeModule" .
 
 
 ###  https://w3id.org/energy-domain/edo#ChokeValve
-:ChokeValve rdf:type owl:Class ;
-            rdfs:subClassOf :ActuatedValve ;
+edo:ChokeValve rdf:type owl:Class ;
+            rdfs:subClassOf edo:ActuatedValve ;
             dcterms:identifier "ChokeValve" .
 
 
 ###  https://w3id.org/energy-domain/edo#CivilEngineering
-:CivilEngineering rdf:type owl:Class ;
-                  rdfs:subClassOf :TechnicalDiscipline ;
+edo:CivilEngineering rdf:type owl:Class ;
+                  rdfs:subClassOf edo:TechnicalDiscipline ;
                   rdfs:label "Civil Engineering"@en ,
                              "Engenharia Civil"@pt-br ;
                   skos:definition "Disciplina de engenharia focada no projeto e construção de infraestrutura."@pt-br ,
@@ -893,34 +892,34 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#ClampInternalDiameter
-:ClampInternalDiameter rdf:type owl:Class ;
-                       rdfs:subClassOf :DomainAttribute ;
+edo:ClampInternalDiameter rdf:type owl:Class ;
+                       rdfs:subClassOf edo:DomainAttribute ;
                        dcterms:accessRights "PUBLIC" ;
                        dcterms:identifier "ClampInternalDiameter" ;
                        skos:definition "Is the clamp internal diameter"@en ;
                        skos:prefLabel "Clamp Internal Diameter"@en ,
                                       "Diâmetro interno do clamp"@pt-br ;
-                       :hasAttributeScope :TypeLevelAttribute ;
-                       :hasTypedValue :floatValue ;
-                       :hasValueCardinality :singleValue .
+                       edo:hasAttributeScope edo:TypeLevelAttribute ;
+                       edo:hasTypedValue edo:floatValue ;
+                       edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#CollarInternalDiameter
-:CollarInternalDiameter rdf:type owl:Class ;
-                        rdfs:subClassOf :DomainAttribute ;
+edo:CollarInternalDiameter rdf:type owl:Class ;
+                        rdfs:subClassOf edo:DomainAttribute ;
                         dcterms:accessRights "PUBLIC" ;
                         dcterms:identifier "CollarInternalDiameter" ;
                         skos:definition "Inner dimension of the collar, to ensure proper fitting and secure attachment."@en ;
                         skos:prefLabel "Collar Internal Diameter"@en ,
                                        "Diâmetro Interno do Colar"@pt-br ;
-                        :hasAttributeScope :TypeLevelAttribute ;
-                        :hasTypedValue :floatValue ;
-                        :hasValueCardinality :singleValue .
+                        edo:hasAttributeScope edo:TypeLevelAttribute ;
+                        edo:hasTypedValue edo:floatValue ;
+                        edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#Commissioning
-:Commissioning rdf:type owl:Class ;
-               rdfs:subClassOf :LifecyclePhase ;
+edo:Commissioning rdf:type owl:Class ;
+               rdfs:subClassOf edo:LifecyclePhase ;
                rdfs:label "Comissionamento"@pt-br ,
                           "Commissioning"@en ;
                skos:definition "Final testing and handover of the system into operational status."@en ,
@@ -928,172 +927,172 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#CommissioningActivity
-:CommissioningActivity rdf:type owl:Class ;
-                       rdfs:subClassOf :CommissioningObject ;
+edo:CommissioningActivity rdf:type owl:Class ;
+                       rdfs:subClassOf edo:CommissioningObject ;
                        dcterms:identifier "CommissioningActivity" ;
                        skos:prefLabel "Atividade de Comissionamento"@pt-br ,
                                       "Commissioning Activity"@en ;
-                       :hasAttribute :Planned_Start_Timestamp ;
-                       :ifc_equivalentClass "IfcTask" ;
-                       :ifc_objectType "Activity" ;
-                       :ifc_predefinedType "USERDEFINED" .
+                       edo:hasAttribute edo:Planned_Start_Timestamp ;
+                       edo:ifc_equivalentClass "IfcTask" ;
+                       edo:ifc_objectType "Activity" ;
+                       edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#CommissioningContract
-:CommissioningContract rdf:type owl:Class ;
-                       rdfs:subClassOf :CommissioningObject ;
+edo:CommissioningContract rdf:type owl:Class ;
+                       rdfs:subClassOf edo:CommissioningObject ;
                        dcterms:identifier "CommissioningContract" ;
                        skos:prefLabel "Commissioning Contract"@en ,
                                       "Contrato de Comissionamento"@pt-br ;
-                       :ifc_equivalentClass "IfcGroup" ;
-                       :ifc_objectType "Contract" ;
-                       :ifc_predefinedType "USERDEFINED" .
+                       edo:ifc_equivalentClass "IfcGroup" ;
+                       edo:ifc_objectType "Contract" ;
+                       edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#CommissioningDigitalProcessStep
-:CommissioningDigitalProcessStep rdf:type owl:Class ;
-                                 rdfs:subClassOf :CommissioningObject ;
+edo:CommissioningDigitalProcessStep rdf:type owl:Class ;
+                                 rdfs:subClassOf edo:CommissioningObject ;
                                  dcterms:identifier "CommissioningDigitalProcessStep" ;
                                  skos:prefLabel "Commissioning Digital Process Step"@en ,
                                                 "Passo do Processo Digital"@pt-br ;
-                                 :ifc_equivalentClass "IfcTask" ;
-                                 :ifc_objectType "CommissioningDigitalProcessStep" ;
-                                 :ifc_predefinedType "USERDEFINED" .
+                                 edo:ifc_equivalentClass "IfcTask" ;
+                                 edo:ifc_objectType "CommissioningDigitalProcessStep" ;
+                                 edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#CommissioningEvidence
-:CommissioningEvidence rdf:type owl:Class ;
-                       rdfs:subClassOf :CommissioningObject ;
+edo:CommissioningEvidence rdf:type owl:Class ;
+                       rdfs:subClassOf edo:CommissioningObject ;
                        dcterms:identifier "CommissioningEvidence" ;
                        skos:prefLabel "Commissioning Evidence"@en ,
                                       "Evidência de Comissionamento"@pt-br ;
-                       :ifc_equivalentClass "IfcDocumentInformation" ;
-                       :ifc_objectType "CommissioningEvidence" ;
-                       :ifc_predefinedType "USERDEFINED" .
+                       edo:ifc_equivalentClass "IfcDocumentInformation" ;
+                       edo:ifc_objectType "CommissioningEvidence" ;
+                       edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#CommissioningIssue
-:CommissioningIssue rdf:type owl:Class ;
-                    rdfs:subClassOf :CommissioningObject ;
+edo:CommissioningIssue rdf:type owl:Class ;
+                    rdfs:subClassOf edo:CommissioningObject ;
                     dcterms:identifier "CommissioningIssue" ;
                     skos:prefLabel "Commissioning Issue"@en ,
                                    "Pendência de Comissionamento"@pt-br ;
-                    :ifc_equivalentClass "IfcClassification" ;
-                    :ifc_objectType "Pendency_Classification" ;
-                    :ifc_predefinedType "USERDEFINED" .
+                    edo:ifc_equivalentClass "IfcClassification" ;
+                    edo:ifc_objectType "Pendency_Classification" ;
+                    edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#CommissioningItemCheck
-:CommissioningItemCheck rdf:type owl:Class ;
-                        rdfs:subClassOf :CommissioningObject ;
+edo:CommissioningItemCheck rdf:type owl:Class ;
+                        rdfs:subClassOf edo:CommissioningObject ;
                         dcterms:identifier "CommissioningItemCheck" ;
                         skos:prefLabel "Commissioning Item Check"@en ,
                                        "Verificação de Item Comissionável"@pt-br ;
-                        :ifc_equivalentClass "IfcClassificationReference" ;
-                        :ifc_objectType "FVI" ;
-                        :ifc_predefinedType "USERDEFINED" .
+                        edo:ifc_equivalentClass "IfcClassificationReference" ;
+                        edo:ifc_objectType "FVI" ;
+                        edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#CommissioningLoopCheck
-:CommissioningLoopCheck rdf:type owl:Class ;
-                        rdfs:subClassOf :CommissioningObject ;
+edo:CommissioningLoopCheck rdf:type owl:Class ;
+                        rdfs:subClassOf edo:CommissioningObject ;
                         dcterms:identifier "CommissioningLoopCheck" ;
                         skos:prefLabel "Commissioning Loop Check"@en ,
                                        "Verificação de Malha"@pt-br ;
-                        :ifc_equivalentClass "IfcClassificationReference" ;
-                        :ifc_objectType "FVM" ;
-                        :ifc_predefinedType "USERDEFINED" .
+                        edo:ifc_equivalentClass "IfcClassificationReference" ;
+                        edo:ifc_objectType "FVM" ;
+                        edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#CommissioningObject
-:CommissioningObject rdf:type owl:Class ;
-                     rdfs:subClassOf :DomainElement .
+edo:CommissioningObject rdf:type owl:Class ;
+                     rdfs:subClassOf edo:DomainElement .
 
 
 ###  https://w3id.org/energy-domain/edo#CommissioningPerson
-:CommissioningPerson rdf:type owl:Class ;
-                     rdfs:subClassOf :CommissioningObject ;
+edo:CommissioningPerson rdf:type owl:Class ;
+                     rdfs:subClassOf edo:CommissioningObject ;
                      dcterms:identifier "CommissioningPerson" ;
                      skos:prefLabel "Commissioning Person"@en ,
                                     "Pessoa"@pt-br ;
-                     :ifc_equivalentClass "IfcPerson" ;
-                     :ifc_objectType "CommissioningPerson" ;
-                     :ifc_predefinedType "USERDEFINED" .
+                     edo:ifc_equivalentClass "IfcPerson" ;
+                     edo:ifc_objectType "CommissioningPerson" ;
+                     edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#CommissioningPreservationOrder
-:CommissioningPreservationOrder rdf:type owl:Class ;
-                                rdfs:subClassOf :CommissioningObject ;
+edo:CommissioningPreservationOrder rdf:type owl:Class ;
+                                rdfs:subClassOf edo:CommissioningObject ;
                                 dcterms:identifier "CommissioningPreservationOrder" ;
                                 skos:prefLabel "Commissioning Preservation Order"@en ,
                                                "Ordem de Preservação"@pt-br ;
-                                :ifc_equivalentClass "IfcClassificationReference" ;
-                                :ifc_objectType "OP" ;
-                                :ifc_predefinedType "USERDEFINED" .
+                                edo:ifc_equivalentClass "IfcClassificationReference" ;
+                                edo:ifc_objectType "OP" ;
+                                edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#CommissioningProgram
-:CommissioningProgram rdf:type owl:Class ;
-                      rdfs:subClassOf :CommissioningObject ;
+edo:CommissioningProgram rdf:type owl:Class ;
+                      rdfs:subClassOf edo:CommissioningObject ;
                       dcterms:identifier "CommissioningProgram" ;
                       skos:prefLabel "Commissioning Program"@en ,
                                      "Programa de Comissionamento"@pt-br ;
-                      :ifc_equivalentClass "IfcGroup" ;
-                      :ifc_objectType "Program" ;
-                      :ifc_predefinedType "USERDEFINED" .
+                      edo:ifc_equivalentClass "IfcGroup" ;
+                      edo:ifc_objectType "Program" ;
+                      edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#CommissioningProject
-:CommissioningProject rdf:type owl:Class ;
-                      rdfs:subClassOf :CommissioningObject ;
+edo:CommissioningProject rdf:type owl:Class ;
+                      rdfs:subClassOf edo:CommissioningObject ;
                       dcterms:identifier "CommissioningProject" ;
                       skos:prefLabel "Commissioning Project"@en ,
                                      "Projeto de Comissionamento"@pt-br ;
-                      :ifc_equivalentClass "IfcProject" ;
-                      :ifc_objectType "Project" ;
-                      :ifc_predefinedType "USERDEFINED" .
+                      edo:ifc_equivalentClass "IfcProject" ;
+                      edo:ifc_objectType "Project" ;
+                      edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#CommissioningResponsibleActor
-:CommissioningResponsibleActor rdf:type owl:Class ;
-                               rdfs:subClassOf :CommissioningObject ;
+edo:CommissioningResponsibleActor rdf:type owl:Class ;
+                               rdfs:subClassOf edo:CommissioningObject ;
                                dcterms:identifier "CommissioningResponsibleActor" ;
                                skos:prefLabel "Ator Responsável"@pt-br ,
                                               "Commissioning Responsible Actor"@en ;
-                               :ifc_equivalentClass "IfcActor" ;
-                               :ifc_objectType "CommissioningResponsibleActor" ;
-                               :ifc_predefinedType "USERDEFINED" .
+                               edo:ifc_equivalentClass "IfcActor" ;
+                               edo:ifc_objectType "CommissioningResponsibleActor" ;
+                               edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#CommissioningResponsibleGroup
-:CommissioningResponsibleGroup rdf:type owl:Class ;
-                               rdfs:subClassOf :CommissioningObject ;
+edo:CommissioningResponsibleGroup rdf:type owl:Class ;
+                               rdfs:subClassOf edo:CommissioningObject ;
                                dcterms:identifier "CommissioningResponsibleGroup" ;
                                skos:prefLabel "Commissioning Responsible Group"@en ,
                                               "Grupo Responsável"@pt-br ;
-                               :ifc_equivalentClass "IfcGroup" ;
-                               :ifc_objectType "CommissioningResponsibleGroup" ;
-                               :ifc_predefinedType "USERDEFINED" .
+                               edo:ifc_equivalentClass "IfcGroup" ;
+                               edo:ifc_objectType "CommissioningResponsibleGroup" ;
+                               edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#CommissioningTask
-:CommissioningTask rdf:type owl:Class ;
-                   rdfs:subClassOf :CommissioningObject ;
+edo:CommissioningTask rdf:type owl:Class ;
+                   rdfs:subClassOf edo:CommissioningObject ;
                    dcterms:identifier "CommissioningTask" ;
                    skos:prefLabel "Commissioning Task"@en ,
                                   "Tarefa de Comissionamento"@pt-br ;
-                   :hasAttribute :Content ,
-                                 :Creator ,
-                                 :CreatorId ,
-                                 :Timestamp ;
-                   :ifc_equivalentClass "IfcTask" ;
-                   :ifc_objectType "Task" ;
-                   :ifc_predefinedType "USERDEFINED" .
+                   edo:hasAttribute edo:Content ,
+                                 edo:Creator ,
+                                 edo:CreatorId ,
+                                 edo:Timestamp ;
+                   edo:ifc_equivalentClass "IfcTask" ;
+                   edo:ifc_objectType "Task" ;
+                   edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#CompactObject
-:CompactObject rdf:type owl:Class ;
-               rdfs:subClassOf :Asset ;
+edo:CompactObject rdf:type owl:Class ;
+               rdfs:subClassOf edo:Asset ;
                dcterms:identifier "CompactObject" ;
                rdfs:label "Compact Object"@en ;
                skos:definition "A mobile physical object, usually manufactured in a standardized manner."@en ;
@@ -1102,8 +1101,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#Component
-:Component rdf:type owl:Class ;
-           rdfs:subClassOf :CompactObject ;
+edo:Component rdf:type owl:Class ;
+           rdfs:subClassOf edo:CompactObject ;
            dcterms:identifier "Component" ;
            skos:definition "Items always found as part of larger objects, with varying levels of complexity."@en ;
            skos:prefLabel "Component"@en ,
@@ -1111,44 +1110,44 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#ComponentDevice
-:ComponentDevice rdf:type owl:Class ;
-                 rdfs:subClassOf :Component ;
+edo:ComponentDevice rdf:type owl:Class ;
+                 rdfs:subClassOf edo:Component ;
                  dcterms:identifier "ComponentDevice" .
 
 
 ###  https://w3id.org/energy-domain/edo#CompositeLayerMaterialType
-:CompositeLayerMaterialType rdf:type owl:Class ;
-                            rdfs:subClassOf :DomainAttribute ;
+edo:CompositeLayerMaterialType rdf:type owl:Class ;
+                            rdfs:subClassOf edo:DomainAttribute ;
                             dcterms:accessRights "PUBLIC" ;
                             dcterms:identifier "CompositeLayerMaterialType" ;
                             skos:definition "Type of material from which an object is made, allowing for precise documentation and categorisation."@en ;
                             skos:prefLabel "Composite Layer Material Type"@en ,
                                            "Tipo de Material da Camada de Compósito"@pt-br ;
-                            :hasAttributeScope :TypeLevelAttribute ;
-                            :hasTypedValue :stringValue ;
-                            :hasValueCardinality :singleValue .
+                            edo:hasAttributeScope edo:TypeLevelAttribute ;
+                            edo:hasTypedValue edo:stringValue ;
+                            edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#CompositeMaterial
-:CompositeMaterial rdf:type owl:Class ;
-                   rdfs:subClassOf :FlexibleStructureLayerMaterial ;
+edo:CompositeMaterial rdf:type owl:Class ;
+                   rdfs:subClassOf edo:FlexibleStructureLayerMaterial ;
                    dcterms:identifier "CompositeMaterial" ;
                    skos:definition "Material composto por dois ou mais componentes distintos, geralmente fibras de reforço e uma matriz, usado na construção de camadas em dutos flexíveis para aplicações subsea. O Material Compósito oferece uma combinação de alta resistência, resistência à corrosão e flexibilidade, tornando-o adequado para suportar as condições severas de ambientes de águas profundas. Seu uso nas camadas do duto flexível melhora a integridade estrutural do duto, resistência à pressão externa e durabilidade sob carregamento cíclico, ao mesmo tempo em que reduz o peso em comparação com materiais metálicos tradicionais."@pt-br ,
                                    "Material made from two or more distinct components, typically reinforcing fibers and a matrix, used in the construction of layers in flexible pipes for subsea applications. The Composite Material offers a combination of high strength, corrosion resistance, and flexibility, making it suitable for withstanding the harsh conditions of deepwater environments. Its use in flexible pipe layers enhances the pipe's structural integrity, resistance to external pressure, and durability under cyclical loading, while also reducing weight compared to traditional metallic materials."@en ;
                    skos:prefLabel "Composite Material"@en ,
                                   "Material Compósito"@pt-br ;
-                   :hasAttribute :CompositeLayerMaterialType ,
-                                 :RuptDefAlongFibers ,
-                                 :RuptDefPerpendFibers ,
-                                 :UltTensStrAlongFibers ,
-                                 :UltTensStrPerpendFibers ;
-                   :ifc_equivalentClass "IfcMaterial" ;
-                   :ifc_objectType "CompositeMaterial" .
+                   edo:hasAttribute edo:CompositeLayerMaterialType ,
+                                 edo:RuptDefAlongFibers ,
+                                 edo:RuptDefPerpendFibers ,
+                                 edo:UltTensStrAlongFibers ,
+                                 edo:UltTensStrPerpendFibers ;
+                   edo:ifc_equivalentClass "IfcMaterial" ;
+                   edo:ifc_objectType "CompositeMaterial" .
 
 
 ###  https://w3id.org/energy-domain/edo#ConceptualDesign
-:ConceptualDesign rdf:type owl:Class ;
-                  rdfs:subClassOf :LifecyclePhase ;
+edo:ConceptualDesign rdf:type owl:Class ;
+                  rdfs:subClassOf edo:LifecyclePhase ;
                   rdfs:label "Conceptual Design"@en ,
                              "Projeto Conceitual"@pt-br ;
                   skos:definition "Fase inicial de projeto focada em viabilidade, definição de escopo e seleção de tecnologia."@pt-br ,
@@ -1156,8 +1155,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#Connection
-:Connection rdf:type owl:Class ;
-            rdfs:subClassOf :DomainElement ;
+edo:Connection rdf:type owl:Class ;
+            rdfs:subClassOf edo:DomainElement ;
             dcterms:identifier "Connection" ;
             skos:definition "The joining point between two components, enabling fluid, gas, or structural continuity. Connections are designed to ensure secure, leak-free operation in harsh subsea environments."@en ;
             skos:prefLabel "Conexão"@pt-br ,
@@ -1165,121 +1164,121 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#ConnectionModule
-:ConnectionModule rdf:type owl:Class ;
-                  rdfs:subClassOf :LineTerminationModule ;
+edo:ConnectionModule rdf:type owl:Class ;
+                  rdfs:subClassOf edo:LineTerminationModule ;
                   dcterms:identifier "ConnectionModule" .
 
 
 ###  https://w3id.org/energy-domain/edo#Content
-:Content rdf:type owl:Class ;
-         rdfs:subClassOf :JustificationAttribute ,
-                         :Registry_GUIDAttribute ,
-                         :StatusAttribute ;
+edo:Content rdf:type owl:Class ;
+         rdfs:subClassOf edo:JustificationAttribute ,
+                         edo:Registry_GUIDAttribute ,
+                         edo:StatusAttribute ;
          dcterms:accessRights "PUBLIC" ;
          dcterms:identifier "Content" ;
          skos:definition "Text field for capturing observations, notes, or details related to the work. It allows for unstructured information to be recorded."@en ;
          skos:prefLabel "Content"@en ;
-         :hasAttributeScope :InstanceLevelAttribute ;
-         :hasTypedValue :stringValue ;
-         :hasValueCardinality :singleValue .
+         edo:hasAttributeScope edo:InstanceLevelAttribute ;
+         edo:hasTypedValue edo:stringValue ;
+         edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#Creator
-:Creator rdf:type owl:Class ;
-         rdfs:subClassOf :JustificationAttribute ,
-                         :Registry_GUIDAttribute ,
-                         :StatusAttribute ;
+edo:Creator rdf:type owl:Class ;
+         rdfs:subClassOf edo:JustificationAttribute ,
+                         edo:Registry_GUIDAttribute ,
+                         edo:StatusAttribute ;
          dcterms:accessRights "PUBLIC" ;
          dcterms:identifier "Creator" ;
          skos:prefLabel "Creator"@en ;
-         :hasAttributeScope :InstanceLevelAttribute ;
-         :hasTypedValue :stringValue ;
-         :hasValueCardinality :singleValue .
+         edo:hasAttributeScope edo:InstanceLevelAttribute ;
+         edo:hasTypedValue edo:stringValue ;
+         edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#CreatorId
-:CreatorId rdf:type owl:Class ;
-           rdfs:subClassOf :JustificationAttribute ,
-                           :Registry_GUIDAttribute ,
-                           :StatusAttribute ;
+edo:CreatorId rdf:type owl:Class ;
+           rdfs:subClassOf edo:JustificationAttribute ,
+                           edo:Registry_GUIDAttribute ,
+                           edo:StatusAttribute ;
            dcterms:accessRights "PUBLIC" ;
            dcterms:identifier "CreatorId" ;
            skos:prefLabel "Creator Id"@en ;
-           :hasAttributeScope :InstanceLevelAttribute ;
-           :hasTypedValue :stringValue ;
-           :hasValueCardinality :singleValue .
+           edo:hasAttributeScope edo:InstanceLevelAttribute ;
+           edo:hasTypedValue edo:stringValue ;
+           edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#CriticalCurvatureOfSlipping
-:CriticalCurvatureOfSlipping rdf:type owl:Class ;
-                             rdfs:subClassOf :BendingStiffnessAttribute ;
+edo:CriticalCurvatureOfSlipping rdf:type owl:Class ;
+                             rdfs:subClassOf edo:BendingStiffnessAttribute ;
                              dcterms:accessRights "PUBLIC" ;
                              dcterms:identifier "CriticalCurvatureOfSlipping" ;
                              skos:definition "Represents the minimum curvature at which slipping or movement between layers or components begins to occur. This property is essential for assessing the flexibility and mechanical behavior of the structure, ensuring that it can maintain stability and performance under bending without experiencing slippage."@en ;
                              skos:prefLabel "Critical Curvature Of Slipping"@en ,
                                             "Curvatura crítica de escorregamento"@pt-br ;
-                             :hasAttributeScope :TypeLevelAttribute ;
-                             :hasTypedValue :floatValue ;
-                             :hasValueCardinality :singleValue .
+                             edo:hasAttributeScope edo:TypeLevelAttribute ;
+                             edo:hasTypedValue edo:floatValue ;
+                             edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#CrossoverModule
-:CrossoverModule rdf:type owl:Class ;
-                 rdfs:subClassOf :FlowControlModule ;
+edo:CrossoverModule rdf:type owl:Class ;
+                 rdfs:subClassOf edo:FlowControlModule ;
                  dcterms:identifier "CrossoverModule" .
 
 
 ###  https://w3id.org/energy-domain/edo#Crushao
-:Crushao rdf:type owl:Class ;
-         rdfs:subClassOf :DomainAttribute .
+edo:Crushao rdf:type owl:Class ;
+         rdfs:subClassOf edo:DomainAttribute .
 
 
 ###  https://w3id.org/energy-domain/edo#CrushingFrictionCoefficientTighteningAttribute
-:CrushingFrictionCoefficientTighteningAttribute rdf:type owl:Class ;
-                                                rdfs:subClassOf :Crushao .
+edo:CrushingFrictionCoefficientTighteningAttribute rdf:type owl:Class ;
+                                                rdfs:subClassOf edo:Crushao .
 
 
 ###  https://w3id.org/energy-domain/edo#CrushingFrictionCoefficientTighteningTableColumn
-:CrushingFrictionCoefficientTighteningTableColumn rdf:type owl:Class ;
-                                                  rdfs:subClassOf :CrushingFrictionCoefficientTighteningAttribute .
+edo:CrushingFrictionCoefficientTighteningTableColumn rdf:type owl:Class ;
+                                                  rdfs:subClassOf edo:CrushingFrictionCoefficientTighteningAttribute .
 
 
 ###  https://w3id.org/energy-domain/edo#CrushingMaximumAllowableTensionAttribute
-:CrushingMaximumAllowableTensionAttribute rdf:type owl:Class ;
-                                          rdfs:subClassOf :Crushao .
+edo:CrushingMaximumAllowableTensionAttribute rdf:type owl:Class ;
+                                          rdfs:subClassOf edo:Crushao .
 
 
 ###  https://w3id.org/energy-domain/edo#CrushingMaximumAllowableTensionTableColumn
-:CrushingMaximumAllowableTensionTableColumn rdf:type owl:Class ;
-                                            rdfs:subClassOf :CrushingMaximumAllowableTensionAttribute .
+edo:CrushingMaximumAllowableTensionTableColumn rdf:type owl:Class ;
+                                            rdfs:subClassOf edo:CrushingMaximumAllowableTensionAttribute .
 
 
 ###  https://w3id.org/energy-domain/edo#CrushingMaximumAllowableTighteningAttribute
-:CrushingMaximumAllowableTighteningAttribute rdf:type owl:Class ;
-                                             rdfs:subClassOf :Crushao .
+edo:CrushingMaximumAllowableTighteningAttribute rdf:type owl:Class ;
+                                             rdfs:subClassOf edo:Crushao .
 
 
 ###  https://w3id.org/energy-domain/edo#CrushingMaximumAllowableTighteningTableColumn
-:CrushingMaximumAllowableTighteningTableColumn rdf:type owl:Class ;
-                                               rdfs:subClassOf :CrushingMaximumAllowableTighteningAttribute .
+edo:CrushingMaximumAllowableTighteningTableColumn rdf:type owl:Class ;
+                                               rdfs:subClassOf edo:CrushingMaximumAllowableTighteningAttribute .
 
 
 ###  https://w3id.org/energy-domain/edo#DamagingPullInStraightLine
-:DamagingPullInStraightLine rdf:type owl:Class ;
-                            rdfs:subClassOf :DomainAttribute ;
+edo:DamagingPullInStraightLine rdf:type owl:Class ;
+                            rdfs:subClassOf edo:DomainAttribute ;
                             dcterms:accessRights "PUBLIC" ;
                             dcterms:identifier "DamagingPullInStraightLine" ;
                             skos:definition "Represents the force applied during a straight-line pull-in operation that could cause damage to a component or system. This property is critical for determining safe operational limits during installation, ensuring that the component can withstand the pulling force without suffering structural damage."@en ;
                             skos:prefLabel "Damaging Pull In Straight Line"@en ,
                                            "Tração Crítica em Linha Reta"@pt-br ;
-                            :hasAttributeScope :TypeLevelAttribute ;
-                            :hasTypedValue :floatValue ;
-                            :hasValueCardinality :singleValue .
+                            edo:hasAttributeScope edo:TypeLevelAttribute ;
+                            edo:hasTypedValue edo:floatValue ;
+                            edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#DeadweightCollar
-:DeadweightCollar rdf:type owl:Class ;
-                  rdfs:subClassOf :SplitCollar ;
+edo:DeadweightCollar rdf:type owl:Class ;
+                  rdfs:subClassOf edo:SplitCollar ;
                   dcterms:identifier "DeadweightCollar" ;
                   skos:altLabel "Ballast Collar"@en ,
                                 "Dead Weight Clamp"@en ,
@@ -1289,14 +1288,14 @@ rdf:value rdf:type owl:DatatypeProperty .
                                   "Componente utilizado em sistemas submersos para fornecer peso adicional a dutos flexíveis, risers ou umbilicais, garantindo a estabilidade e o posicionamento adequados no fundo marinho. O Colar de Peso Morto é projetado para contrabalançar as forças de flutuabilidade, prevenindo o movimento indesejado do duto devido a correntes oceânicas ou outros fatores ambientais. Geralmente feito de materiais densos, ele desempenha um papel crucial na manutenção do alinhamento e da estabilidade das linhas submersas em ambientes dinâmicos, garantindo que o sistema permaneça firmemente ancorado."@pt-br ;
                   skos:prefLabel "Colar de Peso Morto"@pt-br ,
                                  "Deadweight Collar"@en ;
-                  :ifc_equivalentClass "IfcPipeFitting" ;
-                  :ifc_objectType "DeadweightCollar" ;
-                  :ifc_predefinedType "USERDEFINED" .
+                  edo:ifc_equivalentClass "IfcPipeFitting" ;
+                  edo:ifc_objectType "DeadweightCollar" ;
+                  edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#DeclaredValue
-:DeclaredValue rdf:type owl:Class ;
-               rdfs:subClassOf :ValueOrigin ;
+edo:DeclaredValue rdf:type owl:Class ;
+               rdfs:subClassOf edo:ValueOrigin ;
                rdfs:comment "Manually specified value."@en ;
                rdfs:label "Declarado"@pt-br ,
                           "Declared"@en ;
@@ -1305,8 +1304,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#Decommissioning
-:Decommissioning rdf:type owl:Class ;
-                 rdfs:subClassOf :LifecyclePhase ;
+edo:Decommissioning rdf:type owl:Class ;
+                 rdfs:subClassOf edo:LifecyclePhase ;
                  rdfs:label "Decommissioning"@en ,
                             "Descomissionamento"@pt-br ;
                  skos:definition "Permanent removal of the asset from service, including dismantling and disposal."@en ,
@@ -1314,14 +1313,14 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#DeploymentAccessory
-:DeploymentAccessory rdf:type owl:Class ;
-                     rdfs:subClassOf :Accessory ;
+edo:DeploymentAccessory rdf:type owl:Class ;
+                     rdfs:subClassOf edo:Accessory ;
                      dcterms:identifier "DeploymentAccessory" .
 
 
 ###  https://w3id.org/energy-domain/edo#DetailedDesign
-:DetailedDesign rdf:type owl:Class ;
-                rdfs:subClassOf :LifecyclePhase ;
+edo:DetailedDesign rdf:type owl:Class ;
+                rdfs:subClassOf edo:LifecyclePhase ;
                 rdfs:label "Detailed Design"@en ,
                            "Projeto Detalhado"@pt-br ;
                 skos:definition "Comprehensive engineering phase producing detailed drawings, material specifications, and construction plans."@en ,
@@ -1329,74 +1328,74 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#DiffusionTableColumn
-:DiffusionTableColumn rdf:type owl:Class ;
-                      rdfs:subClassOf :DomainAttribute ;
+edo:DiffusionTableColumn rdf:type owl:Class ;
+                      rdfs:subClassOf edo:DomainAttribute ;
                       dcterms:accessRights "PUBLIC" ;
                       dcterms:identifier "DiffusionTable" ;
                       skos:definition "Difusão (Específica para Materiais Poliméricos)"@pt-br ,
                                       "Provides data on the diffusion rates of substances through materials, used to assess how different fluids or gases permeate the structure over time. This information is crucial for evaluating material suitability and predicting long-term performance under specific environmental conditions."@en ;
                       skos:prefLabel "Diffusion Table"@en ,
                                      "Tabela de Difusão"@pt-br ;
-                      :hasAttributeScope :TypeLevelAttribute .
+                      edo:hasAttributeScope edo:TypeLevelAttribute .
 
 
 ###  https://w3id.org/energy-domain/edo#DiffusionTable_DiffusionCoefficient
-:DiffusionTable_DiffusionCoefficient rdf:type owl:Class ;
-                                     rdfs:subClassOf :DiffusionTableColumn ;
+edo:DiffusionTable_DiffusionCoefficient rdf:type owl:Class ;
+                                     rdfs:subClassOf edo:DiffusionTableColumn ;
                                      dcterms:accessRights "PUBLIC" ;
                                      dcterms:identifier "DiffusionTable_DiffusionCoefficient" ;
                                      skos:definition "Represents the rate at which particles, molecules, or substances diffuse through a material. This property is important for evaluating how gases or liquids move within or through a material, helping to understand the behavior of the component, where diffusion can affect performance and integrity."@en ;
                                      skos:prefLabel "Coeficiente de difusão"@pt-br ,
                                                     "Diffusion Coefficient"@en ;
-                                     :hasAttributeScope :TypeLevelAttribute ;
-                                     :hasTypedValue :floatValue ;
-                                     :hasValueCardinality :multiValue .
+                                     edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                     edo:hasTypedValue edo:floatValue ;
+                                     edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#DiffusionTable_MoleculeIdentifier
-:DiffusionTable_MoleculeIdentifier rdf:type owl:Class ;
-                                   rdfs:subClassOf :DiffusionTableColumn ;
+edo:DiffusionTable_MoleculeIdentifier rdf:type owl:Class ;
+                                   rdfs:subClassOf edo:DiffusionTableColumn ;
                                    dcterms:accessRights "PUBLIC" ;
                                    dcterms:identifier "DiffusionTable_MoleculeIdentifier" ;
                                    skos:definition "Specifies the type of molecule. This property identifies the particular molecule involved, which is crucial for understanding the material's interaction with or response to different chemical substances."@en ,
                                                    "Tipo de Molécula (co2, h2s, ch4, h2o,…)"@pt-br ;
                                    skos:prefLabel "Identificador de Molécula"@pt-br ,
                                                   "Molecule Identifier"@en ;
-                                   :hasAttributeScope :TypeLevelAttribute ;
-                                   :hasTypedValue :stringValue ;
-                                   :hasValueCardinality :multiValue .
+                                   edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                   edo:hasTypedValue edo:stringValue ;
+                                   edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#DiffusionTable_PolymerState
-:DiffusionTable_PolymerState rdf:type owl:Class ;
-                             rdfs:subClassOf :DiffusionTableColumn ;
+edo:DiffusionTable_PolymerState rdf:type owl:Class ;
+                             rdfs:subClassOf edo:DiffusionTableColumn ;
                              dcterms:accessRights "PUBLIC" ;
                              dcterms:identifier "DiffusionTable_PolymerState" ;
                              skos:definition "The state of the polymeric material is specified.. This property is crucial for understanding how the material behaves under different conditions and its suitability for various applications."@en ,
                                              "estado do polímero (plastificado, não plastificado,…)"@pt-br ;
                              skos:prefLabel "Estado do Polímero"@pt-br ,
                                             "Polymer State"@en ;
-                             :hasAttributeScope :TypeLevelAttribute ;
-                             :hasTypedValue :stringValue ;
-                             :hasValueCardinality :multiValue .
+                             edo:hasAttributeScope edo:TypeLevelAttribute ;
+                             edo:hasTypedValue edo:stringValue ;
+                             edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#DiffusionTable_Temperature
-:DiffusionTable_Temperature rdf:type owl:Class ;
-                            rdfs:subClassOf :DiffusionTableColumn ;
+edo:DiffusionTable_Temperature rdf:type owl:Class ;
+                            rdfs:subClassOf edo:DiffusionTableColumn ;
                             dcterms:accessRights "PUBLIC" ;
                             dcterms:identifier "DiffusionTable_Temperature" ;
                             skos:definition "Represents the thermal condition or measurement of heat for a component or system. This property is important for assessing how the component performs or operates under specific thermal conditions, ensuring it remains within safe and effective operating limits."@en ;
                             skos:prefLabel "Temperatura"@pt-br ,
                                            "Temperature"@en ;
-                            :hasAttributeScope :TypeLevelAttribute ;
-                            :hasTypedValue :floatValue ;
-                            :hasValueCardinality :multiValue .
+                            edo:hasAttributeScope edo:TypeLevelAttribute ;
+                            edo:hasTypedValue edo:floatValue ;
+                            edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#DimensionalAttribute
-:DimensionalAttribute rdf:type owl:Class ;
-                      rdfs:subClassOf :AttributeDomainCategory ;
+edo:DimensionalAttribute rdf:type owl:Class ;
+                      rdfs:subClassOf edo:AttributeDomainCategory ;
                       rdfs:comment "Represents measurements such as length, diameter, volume."@en ;
                       rdfs:label "Atributo Dimensional"@pt-br ,
                                  "Dimensional Attribute"@en ;
@@ -1405,71 +1404,71 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#DimensioningCriteria
-:DimensioningCriteria rdf:type owl:Class ;
-                      rdfs:subClassOf :LayingMinimumRadiusTableAttribute ;
+edo:DimensioningCriteria rdf:type owl:Class ;
+                      rdfs:subClassOf edo:LayingMinimumRadiusTableAttribute ;
                       dcterms:accessRights "PUBLIC" ;
                       dcterms:identifier "DimensioningCriteria" ;
                       skos:definition "Critério de dimensionamento de raio mínimo de lançamento. Lista pré definida:Linear interpolation (curvature)Most restrictive value between the neighbouring values"@pt-br ,
                                       "Specifies the criteria used to determine the dimensions, providing guidelines and standards for accurate sizing and ensuring that the structure meets required performance and safety specifications."@en ;
                       skos:prefLabel "Critério de Dimensionamento"@pt-br ,
                                      "Dimensioning Criteria"@en ;
-                      :hasAttributeScope :TypeLevelAttribute ;
-                      :hasTypedValue :stringValue ;
-                      :hasValueCardinality :singleValue .
+                      edo:hasAttributeScope edo:TypeLevelAttribute ;
+                      edo:hasTypedValue edo:stringValue ;
+                      edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#DimensionsDrawing
-:DimensionsDrawing rdf:type owl:Class ;
-                   rdfs:subClassOf :ReferenceDrawing ;
+edo:DimensionsDrawing rdf:type owl:Class ;
+                   rdfs:subClassOf edo:ReferenceDrawing ;
                    dcterms:identifier "DimensionsDrawing" ;
                    skos:definition "Desenho técnico que fornece medições detalhadas, especificações geométricas e dados angulares dos componentes utilizados. O Desenho de Cotas inclui informações críticas como comprimento, diâmetro, espessura e ângulos, garantindo a fabricação, montagem e instalação precisas das peças. Esse desenho é essencial para atender aos requisitos de projeto e garantir que todos os componentes se encaixem corretamente no sistema como um todo, apoiando a fabricação eficiente e o controle de qualidade."@pt-br ,
                                    "Technical drawing providing detailed measurements, geometric specifications, and angular data of components. The Dimensions Drawing includes critical information such as length, diameter, thickness, and angles, ensuring the precise fabrication, assembly, and installation of the parts. This drawing is essential for meeting design requirements and ensuring that all components fit accurately within the overall system, supporting efficient manufacturing and quality control."@en ;
                    skos:prefLabel "Desenho de Cotas"@pt-br ,
                                   "Dimensions Drawing"@en ;
-                   :ifc_equivalentClass "IfcDocumentInformation" ;
-                   :ifc_objectType "DimensionsDrawing" .
+                   edo:ifc_equivalentClass "IfcDocumentInformation" ;
+                   edo:ifc_objectType "DimensionsDrawing" .
 
 
 ###  https://w3id.org/energy-domain/edo#DimensionsTableColumn
-:DimensionsTableColumn rdf:type owl:Class ;
-                       rdfs:subClassOf :DrawingDimensionsAttribute .
+edo:DimensionsTableColumn rdf:type owl:Class ;
+                       rdfs:subClassOf edo:DrawingDimensionsAttribute .
 
 
 ###  https://w3id.org/energy-domain/edo#DisplacedVolume
-:DisplacedVolume rdf:type owl:Class ;
-                 rdfs:subClassOf :DomainAttribute ;
+edo:DisplacedVolume rdf:type owl:Class ;
+                 rdfs:subClassOf edo:DomainAttribute ;
                  dcterms:accessRights "PUBLIC" ;
                  dcterms:identifier "DisplacedVolume" ;
                  skos:definition "Refers to the total volume of an object that is submerged or immersed in a fluid. This volume is used to calculate the buoyant force acting on the object and is crucial for understanding its buoyancy and stability in the fluid."@en ;
                  skos:prefLabel "Displaced Volume"@en ,
                                 "Volume Deslocado"@pt-br ;
-                 :hasAttributeScope :TypeLevelAttribute ;
-                 :hasTypedValue :floatValue ;
-                 :hasValueCardinality :singleValue .
+                 edo:hasAttributeScope edo:TypeLevelAttribute ;
+                 edo:hasTypedValue edo:floatValue ;
+                 edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#DistributionConnectionPoint
-:DistributionConnectionPoint rdf:type owl:Class ;
-                             rdfs:subClassOf :LogicalConnection ;
+edo:DistributionConnectionPoint rdf:type owl:Class ;
+                             rdfs:subClassOf edo:LogicalConnection ;
                              dcterms:identifier "DistributionConnectionPoint" ;
                              skos:definition "Localização em um modelo que indica o ponto específico onde os componentes de distribuição de fluido são conectados. O Ponto de Conexão de Distribuição fornece informações precisas para a montagem e instalação desses componentes, garantindo o alinhamento adequado e a funcionalidade dentro do sistema. Este ponto é crucial para definir a interface entre os elementos de distribuição de fluido em sistemas submarinos ou outros sistemas de manuseio de fluido."@pt-br ,
                                              "Location in a model that indicates the specific point where fluid distribution components are connected. The Distribution Connection Point provides precise information for the assembly and installation of these components, ensuring proper alignment and functionality within the system. This point is critical for defining the interface between fluid distribution elements in subsea or other fluid-handling systems."@en ;
                              skos:prefLabel "Distribution Connection Point"@en ,
                                             "Ponto de Conexão de Distribuição"@pt-br ;
-                             :ifc_equivalentClass "IfcDistributionPort" ;
-                             :ifc_objectType "DistributionConnectionPoint" ;
-                             :ifc_predefinedType "USERDEFINED" .
+                             edo:ifc_equivalentClass "IfcDistributionPort" ;
+                             edo:ifc_objectType "DistributionConnectionPoint" ;
+                             edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#DistributionModule
-:DistributionModule rdf:type owl:Class ;
-                    rdfs:subClassOf :AuxiliaryModule ;
+edo:DistributionModule rdf:type owl:Class ;
+                    rdfs:subClassOf edo:AuxiliaryModule ;
                     dcterms:identifier "DistributionModule" .
 
 
 ###  https://w3id.org/energy-domain/edo#Domain
-:Domain rdf:type owl:Class ;
-        rdfs:subClassOf :ElementClassification ;
+edo:Domain rdf:type owl:Class ;
+        rdfs:subClassOf edo:ElementClassification ;
         rdfs:comment "Represents a high-level industrial domain, such as Oil & Gas, Nuclear, or Renewable Energy."@en ;
         rdfs:label "Domínio Industrial"@pt-br ,
                    "Industrial Domain"@en ;
@@ -1478,24 +1477,24 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#DomainAttribute
-:DomainAttribute rdf:type owl:Class .
+edo:DomainAttribute rdf:type owl:Class .
 
 
 ###  https://w3id.org/energy-domain/edo#DomainAuxiliarClass
-:DomainAuxiliarClass rdf:type owl:Class .
+edo:DomainAuxiliarClass rdf:type owl:Class .
 
 
 ###  https://w3id.org/energy-domain/edo#DomainClassification
-:DomainClassification rdf:type owl:Class .
+edo:DomainClassification rdf:type owl:Class .
 
 
 ###  https://w3id.org/energy-domain/edo#DomainElement
-:DomainElement rdf:type owl:Class .
+edo:DomainElement rdf:type owl:Class .
 
 
 ###  https://w3id.org/energy-domain/edo#Downstream
-:Downstream rdf:type owl:Class ;
-            rdfs:subClassOf :OilAndGas ;
+edo:Downstream rdf:type owl:Class ;
+            rdfs:subClassOf edo:OilAndGas ;
             rdfs:label "Downstream"@en ,
                        "Downstream"@pt-br ;
             skos:definition "Oil & Gas sector covering refining, processing, distribution, and retail of petroleum products."@en ,
@@ -1503,302 +1502,302 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#DragAnchor
-:DragAnchor rdf:type owl:Class ;
-            rdfs:subClassOf :Anchor ;
+edo:DragAnchor rdf:type owl:Class ;
+            rdfs:subClassOf edo:Anchor ;
             dcterms:identifier "DragAnchor" .
 
 
 ###  https://w3id.org/energy-domain/edo#DrawingDimensionsAttribute
-:DrawingDimensionsAttribute rdf:type owl:Class ;
-                            rdfs:subClassOf :DomainAttribute ;
+edo:DrawingDimensionsAttribute rdf:type owl:Class ;
+                            rdfs:subClassOf edo:DomainAttribute ;
                             rdfs:label "Drawing Dimensions Table" .
 
 
 ###  https://w3id.org/energy-domain/edo#DrawingDimensionsTable_DimensionDescription
-:DrawingDimensionsTable_DimensionDescription rdf:type owl:Class ;
-                                             rdfs:subClassOf :DimensionsTableColumn ;
+edo:DrawingDimensionsTable_DimensionDescription rdf:type owl:Class ;
+                                             rdfs:subClassOf edo:DimensionsTableColumn ;
                                              dcterms:accessRights "PUBLIC" ;
                                              dcterms:identifier "DrawingDimensionsTable_DimensionDescription" ;
                                              skos:definition "Descrição (Exemplo: Cota do ponto A ao ponto B)"@pt-br ,
                                                              "Provides a detailed description of the dimension. This property explains what the dimension represents, including its relevance and how it relates to other features or components."@en ;
                                              skos:prefLabel "Descrição da Dimensão"@pt-br ,
                                                             "Dimension Description"@en ;
-                                             :hasAttributeScope :TypeLevelAttribute ;
-                                             :hasTypedValue :stringValue ;
-                                             :hasValueCardinality :multiValue .
+                                             edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                             edo:hasTypedValue edo:stringValue ;
+                                             edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#DrawingDimensionsTable_DimensionName
-:DrawingDimensionsTable_DimensionName rdf:type owl:Class ;
-                                      rdfs:subClassOf :DimensionsTableColumn ;
+edo:DrawingDimensionsTable_DimensionName rdf:type owl:Class ;
+                                      rdfs:subClassOf edo:DimensionsTableColumn ;
                                       dcterms:accessRights "PUBLIC" ;
                                       dcterms:identifier "DrawingDimensionsTable_DimensionName" ;
                                       skos:definition "Indicates the name or label assigned to the dimension. This property identifies the specific dimension, which helps in referencing and distinguishing it from other dimensions."@en ;
                                       skos:prefLabel "Dimension Name"@en ,
                                                      "Nome da dimensão"@pt-br ;
-                                      :hasAttributeScope :TypeLevelAttribute ;
-                                      :hasTypedValue :stringValue ;
-                                      :hasValueCardinality :multiValue .
+                                      edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                      edo:hasTypedValue edo:stringValue ;
+                                      edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#DrawingDimensionsTable_DimensionUnit
-:DrawingDimensionsTable_DimensionUnit rdf:type owl:Class ;
-                                      rdfs:subClassOf :DimensionsTableColumn ;
+edo:DrawingDimensionsTable_DimensionUnit rdf:type owl:Class ;
+                                      rdfs:subClassOf edo:DimensionsTableColumn ;
                                       dcterms:accessRights "PUBLIC" ;
                                       dcterms:identifier "DrawingDimensionsTable_DimensionUnit" ;
                                       skos:definition "A unidade pode qualquer uma do SI (Sistema Internacional de Unidades), por exemplo mm, °, etc."@pt-br ,
                                                       "Specifies the unit of measurement for the dimension value, expressed in SI units. For linear dimensions, this would be meters or millimeters, while for angles, it would be degrees. This property ensures that all measurements are clear, consistent, and standardized."@en ;
                                       skos:prefLabel "Dimension Unit"@en ,
                                                      "Unidade de Dimensão"@pt-br ;
-                                      :hasAttributeScope :TypeLevelAttribute ;
-                                      :hasTypedValue :stringValue ;
-                                      :hasValueCardinality :multiValue .
+                                      edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                      edo:hasTypedValue edo:stringValue ;
+                                      edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#DrawingDimensionsTable_DimensionValue
-:DrawingDimensionsTable_DimensionValue rdf:type owl:Class ;
-                                       rdfs:subClassOf :DimensionsTableColumn ;
+edo:DrawingDimensionsTable_DimensionValue rdf:type owl:Class ;
+                                       rdfs:subClassOf edo:DimensionsTableColumn ;
                                        dcterms:accessRights "PUBLIC" ;
                                        dcterms:identifier "DrawingDimensionsTable_DimensionValue" ;
                                        skos:definition "Specifies the actual measurement value of the dimension. This property provides the numerical value for the dimension, which is critical for understanding the size and placement of components or features."@en ;
                                        skos:prefLabel "Dimension Value"@en ,
                                                       "Valor da dimensão"@pt-br ;
-                                       :hasAttributeScope :TypeLevelAttribute ;
-                                       :hasTypedValue :floatValue ;
-                                       :hasValueCardinality :multiValue .
+                                       edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                       edo:hasTypedValue edo:floatValue ;
+                                       edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#DynamicUmbilicalSpan
-:DynamicUmbilicalSpan rdf:type owl:Class ;
-                      rdfs:subClassOf :UmbilicalSpan ;
+edo:DynamicUmbilicalSpan rdf:type owl:Class ;
+                      rdfs:subClassOf edo:UmbilicalSpan ;
                       dcterms:identifier "DynamicUmbilicalSpan" .
 
 
 ###  https://w3id.org/energy-domain/edo#EModVsTempTable_ElasticityModulus
-:EModVsTempTable_ElasticityModulus rdf:type owl:Class ;
-                                   rdfs:subClassOf :DomainAttribute ;
+edo:EModVsTempTable_ElasticityModulus rdf:type owl:Class ;
+                                   rdfs:subClassOf edo:DomainAttribute ;
                                    dcterms:accessRights "PUBLIC" ;
                                    dcterms:identifier "EModVsTempTable_ElasticityModulus" ;
                                    skos:definition "Módulo de elasticidade em função da temperatura (Específica para Materiais Poliméricos)"@pt-br ,
                                                    "Represents the modulus of elasticity values corresponding to specific temperatures. This property provides the stiffness or resistance to deformation of the material at each listed temperature, ensuring that the material's mechanical response is understood under varying thermal conditions."@en ;
                                    skos:prefLabel "Elasticity Modulus Versus Temperature Table - Elasticity Modulus"@en ,
                                                   "Tabela do Módulo de Elasticidade em Função da Temperatura - Módulo de Elasticidade"@pt-br ;
-                                   :hasAttributeScope :TypeLevelAttribute ;
-                                   :hasTypedValue :floatValue ;
-                                   :hasValueCardinality :multiValue .
+                                   edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                   edo:hasTypedValue edo:floatValue ;
+                                   edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#EarlyLeakMaxPressTableAttribute
-:EarlyLeakMaxPressTableAttribute rdf:type owl:Class ;
-                                 rdfs:subClassOf :HydrostaticPressureTestsAttribute .
+edo:EarlyLeakMaxPressTableAttribute rdf:type owl:Class ;
+                                 rdfs:subClassOf edo:HydrostaticPressureTestsAttribute .
 
 
 ###  https://w3id.org/energy-domain/edo#EarlyLeakMaxPressTableColumn
-:EarlyLeakMaxPressTableColumn rdf:type owl:Class ;
-                              rdfs:subClassOf :EarlyLeakMaxPressTableAttribute .
+edo:EarlyLeakMaxPressTableColumn rdf:type owl:Class ;
+                              rdfs:subClassOf edo:EarlyLeakMaxPressTableAttribute .
 
 
 ###  https://w3id.org/energy-domain/edo#EarlyLeakMaxPressTable_Press
-:EarlyLeakMaxPressTable_Press rdf:type owl:Class ;
-                              rdfs:subClassOf :EarlyLeakMaxPressTableColumn ;
+edo:EarlyLeakMaxPressTable_Press rdf:type owl:Class ;
+                              rdfs:subClassOf edo:EarlyLeakMaxPressTableColumn ;
                               dcterms:accessRights "PUBLIC" ;
                               dcterms:identifier "EarlyLeakMaxPressTable_Press" ;
                               skos:definition "Condições de teste dos tramos para Pressão - Máxima - Teste de vazamento hidrostático precoce"@pt-br ,
                                               "The maximum pressure applied during the Early Leak Test, verifying resistance under extreme pressure conditions."@en ;
                               skos:prefLabel "Early Leak Maximum Pressure Table - Pressure"@en ,
                                              "Tabela de Pressão Máxima de Vazamento Precoce - Pressão"@pt-br ;
-                              :hasAttributeScope :InstanceLevelAttribute ;
-                              :hasTypedValue :floatValue ;
-                              :hasValueCardinality :multiValue .
+                              edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                              edo:hasTypedValue edo:floatValue ;
+                              edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#EarlyLeakMaxPressTable_PressIntValStrat
-:EarlyLeakMaxPressTable_PressIntValStrat rdf:type owl:Class ;
-                                         rdfs:subClassOf :EarlyLeakMaxPressTableAttribute ;
+edo:EarlyLeakMaxPressTable_PressIntValStrat rdf:type owl:Class ;
+                                         rdfs:subClassOf edo:EarlyLeakMaxPressTableAttribute ;
                                          dcterms:accessRights "PUBLIC" ;
                                          dcterms:identifier "EarlyLeakMaxPressTable_PressIntValStrat" ;
                                          skos:definition "Condições de teste dos tramos para Estratégia de valores intermediários - Máximo - Teste de vazamento hidrostático precoce"@pt-br ,
                                                          "Strategy used to calculate intermediate values between maximum conditions during the Early Leak Test."@en ;
                                          skos:prefLabel "Early Leak Maximum Pressure Table - Pressure Intermediate Values Strategy"@en ,
                                                         "Tabela de Pressão Máxima de Vazamento Precoce - Estratégia de Valores Intermediários de Pressão"@pt-br ;
-                                         :hasAttributeScope :InstanceLevelAttribute ;
-                                         :hasTypedValue :stringValue ;
-                                         :hasValueCardinality :singleValue .
+                                         edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                         edo:hasTypedValue edo:stringValue ;
+                                         edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#EarlyLeakMaxPressTable_PressValRef
-:EarlyLeakMaxPressTable_PressValRef rdf:type owl:Class ;
-                                    rdfs:subClassOf :EarlyLeakMaxPressTableColumn ;
+edo:EarlyLeakMaxPressTable_PressValRef rdf:type owl:Class ;
+                                    rdfs:subClassOf edo:EarlyLeakMaxPressTableColumn ;
                                     dcterms:accessRights "PUBLIC" ;
                                     dcterms:identifier "EarlyLeakMaxPressTable_PressValRef" ;
                                     skos:definition "Comentários Condições de teste dos tramos para - Máximo - Teste de vazamento hidrostático precoce"@pt-br ,
                                                     "Specifies the reference pressure used to determine the Early Leak Maximum Pressure value."@en ;
                                     skos:prefLabel "Early Leak Maximum Pressure Table - Pressure Value Reference"@en ,
                                                    "Tabela de Pressão Máxima de Vazamento Precoce - Referência de Valor de Pressão"@pt-br ;
-                                    :hasAttributeScope :InstanceLevelAttribute ;
-                                    :hasTypedValue :stringValue ;
-                                    :hasValueCardinality :multiValue .
+                                    edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                    edo:hasTypedValue edo:stringValue ;
+                                    edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#EarlyLeakMaxPressTable_PressValRefMult
-:EarlyLeakMaxPressTable_PressValRefMult rdf:type owl:Class ;
-                                        rdfs:subClassOf :EarlyLeakMaxPressTableColumn ;
+edo:EarlyLeakMaxPressTable_PressValRefMult rdf:type owl:Class ;
+                                        rdfs:subClassOf edo:EarlyLeakMaxPressTableColumn ;
                                         dcterms:accessRights "PUBLIC" ;
                                         dcterms:identifier "EarlyLeakMaxPressTable_PressValRefMult" ;
                                         skos:definition "Early Leak Maximum Pressure Table - Pressure Value Reference Multiplier"@pt-br ,
                                                         "The multiplier applied to the reference pressure to determine the Early Leak Maximum Pressure value."@en ;
                                         skos:prefLabel "Early Leak Maximum Pressure Table - Pressure Value Reference Multiplier"@en ,
                                                        "Tabela de Pressão Máxima de Vazamento Precoce - Multiplicador de Referência de Valor de Pressão"@pt-br ;
-                                        :hasAttributeScope :InstanceLevelAttribute ;
-                                        :hasTypedValue :floatValue ;
-                                        :hasValueCardinality :multiValue .
+                                        edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                        edo:hasTypedValue edo:floatValue ;
+                                        edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#EarlyLeakMaxPressTable_TensLimit
-:EarlyLeakMaxPressTable_TensLimit rdf:type owl:Class ;
-                                  rdfs:subClassOf :EarlyLeakMaxPressTableColumn ;
+edo:EarlyLeakMaxPressTable_TensLimit rdf:type owl:Class ;
+                                  rdfs:subClassOf edo:EarlyLeakMaxPressTableColumn ;
                                   dcterms:accessRights "PUBLIC" ;
                                   dcterms:identifier "EarlyLeakMaxPressTable_TensLimit" ;
                                   skos:definition "Condições de teste dos tramos para Tensão - Máxima - Teste de vazamento hidrostático precoce"@pt-br ,
                                                   "Tensile limit condition that must be respected to avoid damaging the tested product."@en ;
                                   skos:prefLabel "Early Leak Maximum Pressure Table - Tensile Limit"@en ,
                                                  "Tabela de Pressão Máxima de Vazamento Precoce - Limite de Tração"@pt-br ;
-                                  :hasAttributeScope :InstanceLevelAttribute ;
-                                  :hasTypedValue :floatValue ;
-                                  :hasValueCardinality :multiValue .
+                                  edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                  edo:hasTypedValue edo:floatValue ;
+                                  edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#EarlyLeakMaxPressTable_TensLimitValRef
-:EarlyLeakMaxPressTable_TensLimitValRef rdf:type owl:Class ;
-                                        rdfs:subClassOf :EarlyLeakMaxPressTableColumn ;
+edo:EarlyLeakMaxPressTable_TensLimitValRef rdf:type owl:Class ;
+                                        rdfs:subClassOf edo:EarlyLeakMaxPressTableColumn ;
                                         dcterms:accessRights "PUBLIC" ;
                                         dcterms:identifier "EarlyLeakMaxPressTable_TensLimitValRef" ;
                                         skos:definition "Indicates the basis used to establish the tensile limit value during the Early Leak Maximum Pressure Test, ensuring the product's tensile strength is respected to avoid damage."@en ;
                                         skos:prefLabel "Early Leak Maximum Pressure Table - Tensile Limit Value Reference"@en ,
                                                        "Tabela de Pressão Máxima de Vazamento Precoce - Referência do Limite de Tração"@pt-br ;
-                                        :hasAttributeScope :InstanceLevelAttribute ;
-                                        :hasTypedValue :stringValue ;
-                                        :hasValueCardinality :multiValue .
+                                        edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                        edo:hasTypedValue edo:stringValue ;
+                                        edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#EarlyLeakNomPressTableAttribute
-:EarlyLeakNomPressTableAttribute rdf:type owl:Class ;
-                                 rdfs:subClassOf :HydrostaticPressureTestsAttribute .
+edo:EarlyLeakNomPressTableAttribute rdf:type owl:Class ;
+                                 rdfs:subClassOf edo:HydrostaticPressureTestsAttribute .
 
 
 ###  https://w3id.org/energy-domain/edo#EarlyLeakNomPressTableColumn
-:EarlyLeakNomPressTableColumn rdf:type owl:Class ;
-                              rdfs:subClassOf :EarlyLeakNomPressTableAttribute .
+edo:EarlyLeakNomPressTableColumn rdf:type owl:Class ;
+                              rdfs:subClassOf edo:EarlyLeakNomPressTableAttribute .
 
 
 ###  https://w3id.org/energy-domain/edo#EarlyLeakNomPressTable_Press
-:EarlyLeakNomPressTable_Press rdf:type owl:Class ;
-                              rdfs:subClassOf :EarlyLeakNomPressTableColumn ;
+edo:EarlyLeakNomPressTable_Press rdf:type owl:Class ;
+                              rdfs:subClassOf edo:EarlyLeakNomPressTableColumn ;
                               dcterms:accessRights "PUBLIC" ;
                               dcterms:identifier "EarlyLeakNomPressTable_Press" ;
                               skos:definition "Condições de teste dos tramos para Pressão - Nominal - Teste de vazamento hidrostático precoce"@pt-br ,
                                               "The nominal pressure applied during the Early Leak Test, verifying standard operational conditions for leakage detection."@en ;
                               skos:prefLabel "Early Leak Nominal Pressure Table - Pressure"@en ,
                                              "Tabela de Pressão Nominal de Vazamento Precoce - Pressão"@pt-br ;
-                              :hasAttributeScope :InstanceLevelAttribute ;
-                              :hasTypedValue :floatValue ;
-                              :hasValueCardinality :multiValue .
+                              edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                              edo:hasTypedValue edo:floatValue ;
+                              edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#EarlyLeakNomPressTable_PressIntValStrat
-:EarlyLeakNomPressTable_PressIntValStrat rdf:type owl:Class ;
-                                         rdfs:subClassOf :EarlyLeakNomPressTableAttribute ;
+edo:EarlyLeakNomPressTable_PressIntValStrat rdf:type owl:Class ;
+                                         rdfs:subClassOf edo:EarlyLeakNomPressTableAttribute ;
                                          dcterms:accessRights "PUBLIC" ;
                                          dcterms:identifier "EarlyLeakNomPressTable_PressIntValStrat" ;
                                          skos:definition "Condições de teste dos tramos para Estratégia de valores intermediários - Nominal - Teste de vazamento hidrostático precoce"@pt-br ,
                                                          "Strategy used to calculate intermediate Pressure values between nominal conditions during the Early Leak Test."@en ;
                                          skos:prefLabel "Early Leak Nominal Pressure Table - Pressure Intermediate Values Strategy"@en ,
                                                         "Tabela de Pressão Nominal de Vazamento Precoce - Estratégia de Valores Intermediários de Pressão"@pt-br ;
-                                         :hasAttributeScope :InstanceLevelAttribute ;
-                                         :hasTypedValue :stringValue ;
-                                         :hasValueCardinality :singleValue .
+                                         edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                         edo:hasTypedValue edo:stringValue ;
+                                         edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#EarlyLeakNomPressTable_PressValRef
-:EarlyLeakNomPressTable_PressValRef rdf:type owl:Class ;
-                                    rdfs:subClassOf :EarlyLeakNomPressTableColumn ;
+edo:EarlyLeakNomPressTable_PressValRef rdf:type owl:Class ;
+                                    rdfs:subClassOf edo:EarlyLeakNomPressTableColumn ;
                                     dcterms:accessRights "PUBLIC" ;
                                     dcterms:identifier "EarlyLeakNomPressTable_PressValRef" ;
                                     skos:definition "Comentários Condições de teste dos tramos para - Nominal - Teste de vazamento hidrostático precoce"@pt-br ,
                                                     "Specifies the reference pressure used to determine the Early Leak Nominal Pressure value."@en ;
                                     skos:prefLabel "Early Leak Nominal Pressure Table - Pressure Value Reference"@en ,
                                                    "Tabela de Pressão Nominal de Vazamento Precoce - Referência de Valor de Pressão"@pt-br ;
-                                    :hasAttributeScope :InstanceLevelAttribute ;
-                                    :hasTypedValue :stringValue ;
-                                    :hasValueCardinality :multiValue .
+                                    edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                    edo:hasTypedValue edo:stringValue ;
+                                    edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#EarlyLeakNomPressTable_PressValRefMult
-:EarlyLeakNomPressTable_PressValRefMult rdf:type owl:Class ;
-                                        rdfs:subClassOf :EarlyLeakNomPressTableColumn ;
+edo:EarlyLeakNomPressTable_PressValRefMult rdf:type owl:Class ;
+                                        rdfs:subClassOf edo:EarlyLeakNomPressTableColumn ;
                                         dcterms:accessRights "PUBLIC" ;
                                         dcterms:identifier "EarlyLeakNomPressTable_PressValRefMult" ;
                                         skos:definition "The multiplier applied to the reference pressure to determine the Early Leak Nominal Pressure value."@en ;
                                         skos:prefLabel "Early Leak Nominal Pressure Table - Pressure Value Reference Multiplier"@en ,
                                                        "Tabela de Pressão Nominal de Vazamento Precoce - Multiplicador de Referência de Valor de Pressão"@pt-br ;
-                                        :hasAttributeScope :InstanceLevelAttribute ;
-                                        :hasTypedValue :floatValue ;
-                                        :hasValueCardinality :multiValue .
+                                        edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                        edo:hasTypedValue edo:floatValue ;
+                                        edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#EarlyLeakNomPressTable_TensLimit
-:EarlyLeakNomPressTable_TensLimit rdf:type owl:Class ;
-                                  rdfs:subClassOf :EarlyLeakNomPressTableColumn ;
+edo:EarlyLeakNomPressTable_TensLimit rdf:type owl:Class ;
+                                  rdfs:subClassOf edo:EarlyLeakNomPressTableColumn ;
                                   dcterms:accessRights "PUBLIC" ;
                                   dcterms:identifier "EarlyLeakNomPressTable_TensLimit" ;
                                   skos:definition "Condições de teste dos tramos para Tensão - Nominal - Teste de vazamento hidrostático precoce"@pt-br ,
                                                   "Tensile limit condition that must be respected to avoid damaging the tested product."@en ;
                                   skos:prefLabel "Early Leak Nominal Pressure Table - Tensile Limit"@en ,
                                                  "Tabela de Pressão Nominal de Vazamento Precoce - Limite de Tração"@pt-br ;
-                                  :hasAttributeScope :InstanceLevelAttribute ;
-                                  :hasTypedValue :floatValue ;
-                                  :hasValueCardinality :multiValue .
+                                  edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                  edo:hasTypedValue edo:floatValue ;
+                                  edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#EarlyLeakNomPressTable_TensLimitValRef
-:EarlyLeakNomPressTable_TensLimitValRef rdf:type owl:Class ;
-                                        rdfs:subClassOf :EarlyLeakNomPressTableColumn ;
+edo:EarlyLeakNomPressTable_TensLimitValRef rdf:type owl:Class ;
+                                        rdfs:subClassOf edo:EarlyLeakNomPressTableColumn ;
                                         dcterms:accessRights "PUBLIC" ;
                                         dcterms:identifier "EarlyLeakNomPressTable_TensLimitValRef" ;
                                         skos:definition "Indicates the basis used to establish the tensile limit value during the Early Leak Nominal Pressure Test, ensuring the product's tensile strength is respected to avoid damage."@en ;
                                         skos:prefLabel "Early Leak Nominal Pressure Table - Tensile Limit Value Reference"@en ,
                                                        "Tabela de Pressão Nominal de Vazamento Precoce - Referência do Limite de Tração"@pt-br ;
-                                        :hasAttributeScope :InstanceLevelAttribute ;
-                                        :hasTypedValue :stringValue ;
-                                        :hasValueCardinality :multiValue .
+                                        edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                        edo:hasTypedValue edo:stringValue ;
+                                        edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#ElasticityModulusAt23Degrees
-:ElasticityModulusAt23Degrees rdf:type owl:Class ;
-                              rdfs:subClassOf :DomainAttribute ;
+edo:ElasticityModulusAt23Degrees rdf:type owl:Class ;
+                              rdfs:subClassOf edo:DomainAttribute ;
                               dcterms:accessRights "PUBLIC" ;
                               dcterms:identifier "ElasticityModulusAt23Degrees" ;
                               skos:definition "Módulo de elasticidade a 23 graus Celsius (Específica para Materiais Metálicos e Poliméricos)"@pt-br ,
                                               "Specifies the modulus of elasticity of the material at 23 degrees Celsius, indicating its stiffness or resistance to deformation under stress at this temperature. This property is crucial for determining how the flexible structure responds to mechanical loads, ensuring that it maintains structural integrity."@en ;
                               skos:prefLabel "Elasticity Modulus At 23 Degrees"@en ,
                                              "Módulo de Elasticidade a 23 Graus Celsius"@pt-br ;
-                              :hasAttributeScope :TypeLevelAttribute ;
-                              :hasTypedValue :floatValue ;
-                              :hasValueCardinality :singleValue .
+                              edo:hasAttributeScope edo:TypeLevelAttribute ;
+                              edo:hasTypedValue edo:floatValue ;
+                              edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#ElectricalCable
-:ElectricalCable rdf:type owl:Class ;
-                 rdfs:subClassOf :FunctionLine ;
+edo:ElectricalCable rdf:type owl:Class ;
+                 rdfs:subClassOf edo:FunctionLine ;
                  dcterms:identifier "ElectricalCable" ;
-                 :ifc_equivalentClass "IfcCableSegment" ;
-                 :ifc_objectType "ElectricalCable" ;
-                 :ifc_predefinedType "USERDEFINED" .
+                 edo:ifc_equivalentClass "IfcCableSegment" ;
+                 edo:ifc_objectType "ElectricalCable" ;
+                 edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#ElectricalEngineering
-:ElectricalEngineering rdf:type owl:Class ;
-                       rdfs:subClassOf :TechnicalDiscipline ;
+edo:ElectricalEngineering rdf:type owl:Class ;
+                       rdfs:subClassOf edo:TechnicalDiscipline ;
                        rdfs:label "Electrical Engineering"@en ,
                                   "Engenharia Elétrica"@pt-br ;
                        skos:definition "Disciplina de engenharia focada em sistemas elétricos, distribuição e geração de energia."@pt-br ,
@@ -1806,31 +1805,31 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#ElectricalJumper
-:ElectricalJumper rdf:type owl:Class ;
-                  rdfs:subClassOf :Jumper ;
+edo:ElectricalJumper rdf:type owl:Class ;
+                  rdfs:subClassOf edo:Jumper ;
                   dcterms:identifier "ElectricalJumper" .
 
 
 ###  https://w3id.org/energy-domain/edo#ElectricalPowerJumper
-:ElectricalPowerJumper rdf:type owl:Class ;
-                       rdfs:subClassOf :Jumper ;
+edo:ElectricalPowerJumper rdf:type owl:Class ;
+                       rdfs:subClassOf edo:Jumper ;
                        dcterms:identifier "ElectricalPowerJumper" .
 
 
 ###  https://w3id.org/energy-domain/edo#ElectronicDevice
-:ElectronicDevice rdf:type owl:Class ;
-                  rdfs:subClassOf :ComponentDevice ;
+edo:ElectronicDevice rdf:type owl:Class ;
+                  rdfs:subClassOf edo:ComponentDevice ;
                   dcterms:identifier "ElectronicDevice" .
 
 
 ###  https://w3id.org/energy-domain/edo#ElementClassification
-:ElementClassification rdf:type owl:Class ;
-                       rdfs:subClassOf :DomainClassification .
+edo:ElementClassification rdf:type owl:Class ;
+                       rdfs:subClassOf edo:DomainClassification .
 
 
 ###  https://w3id.org/energy-domain/edo#EndFitting
-:EndFitting rdf:type owl:Class ;
-            rdfs:subClassOf :PipeTermination ;
+edo:EndFitting rdf:type owl:Class ;
+            rdfs:subClassOf edo:PipeTermination ;
             dcterms:identifier "EndFitting" ;
             skos:altLabel "Connector Fitting"@en ,
                           "End Termination"@en ,
@@ -1840,26 +1839,26 @@ rdf:value rdf:type owl:DatatypeProperty .
                             "Componente utilizado em dutos flexíveis para fornecer uma transição segura entre o duto flexível e estruturas rígidas, como equipamentos submersos ou instalações no topo, bem como para conectar duas seções de duto flexível. O Terminador garante a integridade estrutural e o vedamento do duto, permitindo a conexão da linha flexível a outros equipamentos ou seções, resistindo a pressões internas e forças ambientais. É uma interface crítica que acomoda as cargas mecânicas, hidráulicas e térmicas do duto, garantindo desempenho confiável a longo prazo em condições submarinas adversas."@pt-br ;
             skos:prefLabel "Conector de Extremidade"@pt-br ,
                            "End fitting"@en ;
-            :hasAttribute :BoreDiameter ,
-                          :FlangeFaceType ,
-                          :FlangeType ,
-                          :HasFaceORing ,
-                          :HasModaSensor ,
-                          :HasN2InjectionPort ,
-                          :RingGasketInnerDIameter ,
-                          :RingGasketOuterDiameter ,
-                          :RingGasketPressureRating ,
-                          :RingGasketSpecification ,
-                          :RingGasketStandard ,
-                          :RingGasketType ;
-            :ifc_equivalentClass "IfcPipeFitting" ;
-            :ifc_objectType "EndFitting" ;
-            :ifc_predefinedType "USERDEFINED" .
+            edo:hasAttribute edo:BoreDiameter ,
+                          edo:FlangeFaceType ,
+                          edo:FlangeType ,
+                          edo:HasFaceORing ,
+                          edo:HasModaSensor ,
+                          edo:HasN2InjectionPort ,
+                          edo:RingGasketInnerDIameter ,
+                          edo:RingGasketOuterDiameter ,
+                          edo:RingGasketPressureRating ,
+                          edo:RingGasketSpecification ,
+                          edo:RingGasketStandard ,
+                          edo:RingGasketType ;
+            edo:ifc_equivalentClass "IfcPipeFitting" ;
+            edo:ifc_objectType "EndFitting" ;
+            edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#EnergyStorage
-:EnergyStorage rdf:type owl:Class ;
-               rdfs:subClassOf :Domain ;
+edo:EnergyStorage rdf:type owl:Class ;
+               rdfs:subClassOf edo:Domain ;
                rdfs:label "Armazenamento de Energia"@pt-br ,
                           "Energy Storage"@en ;
                skos:definition "Technologies for storing energy, such as batteries, pumped hydro, or compressed air."@en ,
@@ -1867,14 +1866,14 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#Equipment
-:Equipment rdf:type owl:Class ;
-           rdfs:subClassOf :CompactObject ;
+edo:Equipment rdf:type owl:Class ;
+           rdfs:subClassOf edo:CompactObject ;
            dcterms:identifier "Equipment" .
 
 
 ###  https://w3id.org/energy-domain/edo#EquipmentEngineering
-:EquipmentEngineering rdf:type owl:Class ;
-                      rdfs:subClassOf :TechnicalDiscipline ;
+edo:EquipmentEngineering rdf:type owl:Class ;
+                      rdfs:subClassOf edo:TechnicalDiscipline ;
                       rdfs:label "Engenharia de Equipamentos"@pt-br ,
                                  "Equipment Engineering"@en ;
                       skos:definition "Disciplina de engenharia focada no projeto e especificação de equipamentos industriais."@pt-br ,
@@ -1882,8 +1881,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#EquipmentLocation
-:EquipmentLocation rdf:type owl:Class ;
-                   rdfs:subClassOf :PointLocation ;
+edo:EquipmentLocation rdf:type owl:Class ;
+                   rdfs:subClassOf edo:PointLocation ;
                    dcterms:identifier "EquipmentLocation" ;
                    skos:definition "Base for installation sites for large underwater equipment."@en ;
                    skos:prefLabel "Equipment Location"@en ,
@@ -1891,48 +1890,48 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#ErosionalVelocity
-:ErosionalVelocity rdf:type owl:Class ;
-                   rdfs:subClassOf :DomainAttribute ;
+edo:ErosionalVelocity rdf:type owl:Class ;
+                   rdfs:subClassOf edo:DomainAttribute ;
                    dcterms:accessRights "PUBLIC" ;
                    dcterms:identifier "ErosionalVelocity" ;
                    skos:definition "Represents the maximum velocity of a fluid at which erosion of the material begins to occur. This property is crucial for determining the operational limits of the system, ensuring that the material can withstand fluid flow without suffering erosive damage."@en ;
                    skos:prefLabel "Erosional Velocity"@en ,
                                   "Velocidade erosional"@pt-br ;
-                   :hasAttributeScope :TypeLevelAttribute ;
-                   :hasTypedValue :stringValue ;
-                   :hasValueCardinality :singleValue .
+                   edo:hasAttributeScope edo:TypeLevelAttribute ;
+                   edo:hasTypedValue edo:stringValue ;
+                   edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#ExecutiveProjectRevision
-:ExecutiveProjectRevision rdf:type owl:Class ;
-                          rdfs:subClassOf :DomainAttribute ;
+edo:ExecutiveProjectRevision rdf:type owl:Class ;
+                          rdfs:subClassOf edo:DomainAttribute ;
                           dcterms:accessRights "PUBLIC" ;
                           dcterms:identifier "ExecutiveProjectRevision" ;
                           skos:definition "Indicates the revision number of the executive project, represented as a numeric value that is incremented with each new submission (e.g., 0000, 0001, 0002), stored as text for consistency in formatting."@en ,
                                           "Revisão do projeto executivo  Valor numérico incrementado a cada novo envio (0000, 0001, 0002 e etc.) como texto"@pt-br ;
                           skos:prefLabel "Executive Project Revision"@en ,
                                          "Revisão do Projeto Executivo"@pt-br ;
-                          :hasAttributeScope :InstanceLevelAttribute ;
-                          :hasTypedValue :stringValue ;
-                          :hasValueCardinality :singleValue .
+                          edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                          edo:hasTypedValue edo:stringValue ;
+                          edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#ExternalDiameter
-:ExternalDiameter rdf:type owl:Class ;
-                  rdfs:subClassOf :DomainAttribute ;
+edo:ExternalDiameter rdf:type owl:Class ;
+                  rdfs:subClassOf edo:DomainAttribute ;
                   dcterms:accessRights "PUBLIC" ;
                   dcterms:identifier "ExternalDiameter" ;
                   skos:definition "Distance measured across the outermost points, passing through the center."@en ;
                   skos:prefLabel "Diâmetro externo"@pt-br ,
                                  "External Diameter"@en ;
-                  :hasAttributeScope :TypeLevelAttribute ;
-                  :hasTypedValue :floatValue ;
-                  :hasValueCardinality :singleValue .
+                  edo:hasAttributeScope edo:TypeLevelAttribute ;
+                  edo:hasTypedValue edo:floatValue ;
+                  edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#FEED
-:FEED rdf:type owl:Class ;
-      rdfs:subClassOf :LifecyclePhase ;
+edo:FEED rdf:type owl:Class ;
+      rdfs:subClassOf edo:LifecyclePhase ;
       rdfs:label "FEED (Front-End Engineering Design)"@en ,
                  "FEED (Projeto Básico de Engenharia)"@pt-br ;
       skos:definition "Fase intermediária entre o projeto conceitual e detalhado, refinando detalhes técnicos e de custo."@pt-br ,
@@ -1940,33 +1939,33 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#FSHRLowerAssembly
-:FSHRLowerAssembly rdf:type owl:Class ;
-                   rdfs:subClassOf :FlowControlEquipment ;
+edo:FSHRLowerAssembly rdf:type owl:Class ;
+                   rdfs:subClassOf edo:FlowControlEquipment ;
                    dcterms:identifier "FSHRLowerAssembly" .
 
 
 ###  https://w3id.org/energy-domain/edo#FSHRUpperAssembly
-:FSHRUpperAssembly rdf:type owl:Class ;
-                   rdfs:subClassOf :FlowControlEquipment ;
+edo:FSHRUpperAssembly rdf:type owl:Class ;
+                   rdfs:subClassOf edo:FlowControlEquipment ;
                    dcterms:identifier "FSHRUpperAssembly" .
 
 
 ###  https://w3id.org/energy-domain/edo#FabricTape
-:FabricTape rdf:type owl:Class ;
-            rdfs:subClassOf :TapeLayer ;
+edo:FabricTape rdf:type owl:Class ;
+            rdfs:subClassOf edo:TapeLayer ;
             dcterms:identifier "FabricTape" ;
             skos:definition "Material used in subsea flexible pipe construction, typically applied as a wrapping layer to provide protection and containment for internal components. Fabric Tape is designed to secure and hold various layers of the pipe in place during manufacturing and operation, preventing displacement or damage to the underlying layers. It also adds a layer of abrasion resistance, contributing to the overall durability of the pipe in dynamic subsea environments. Made from high-strength, flexible materials, Fabric Tape plays a key role in maintaining the integrity of the flexible pipe structure."@en ,
                             "Material utilizado na construção de dutos flexíveis, geralmente aplicado como uma camada de envolvimento para fornecer proteção e contenção para os componentes internos. A Fita Construtiva é projetada para segurar e manter as várias camadas do duto no lugar durante a fabricação e operação, evitando o deslocamento ou danos às camadas subjacentes. Ela também adiciona uma camada de resistência à abrasão, contribuindo para a durabilidade geral do duto em ambientes dinâmicos. Feita de materiais flexíveis e de alta resistência, a Fita Construtiva desempenha um papel crucial na manutenção da integridade da estrutura do duto flexível."@pt-br ;
             skos:prefLabel "Fabric Tape"@en ,
                            "Fita Construtiva"@pt-br ;
-            :ifc_equivalentClass "IfcPipeSegment" ;
-            :ifc_objectType "FabricTape" ;
-            :ifc_predefinedType "USERDEFINED" .
+            edo:ifc_equivalentClass "IfcPipeSegment" ;
+            edo:ifc_objectType "FabricTape" ;
+            edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#Fabrication
-:Fabrication rdf:type owl:Class ;
-             rdfs:subClassOf :LifecyclePhase ;
+edo:Fabrication rdf:type owl:Class ;
+             rdfs:subClassOf edo:LifecyclePhase ;
              rdfs:label "Fabrication"@en ,
                         "Fabricação"@pt-br ;
              skos:definition "Fabricação e montagem de componentes, módulos ou estruturas em oficinas ou estaleiros."@pt-br ,
@@ -1974,108 +1973,108 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#FatMaxPress
-:FatMaxPress rdf:type owl:Class ;
-             rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:FatMaxPress rdf:type owl:Class ;
+             rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
              dcterms:accessRights "PUBLIC" ;
              dcterms:identifier "FatMaxPress" ;
              skos:definition "Condições de teste dos tramos para Pressão - Máxima - FAT hidrostática"@pt-br ,
                              "The maximum pressure applied during the Factory Acceptance Test (FAT) to ensure the equipment can withstand extreme conditions."@en ;
              skos:prefLabel "Factory Acceptance Test Maximum Pressure"@en ,
                             "Pressão Máxima para o Teste de Aceitação na Fábrica"@pt-br ;
-             :hasAttributeScope :InstanceLevelAttribute ;
-             :hasTypedValue :floatValue ;
-             :hasValueCardinality :singleValue .
+             edo:hasAttributeScope edo:InstanceLevelAttribute ;
+             edo:hasTypedValue edo:floatValue ;
+             edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#FatMaxPressValRef
-:FatMaxPressValRef rdf:type owl:Class ;
-                   rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:FatMaxPressValRef rdf:type owl:Class ;
+                   rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
                    dcterms:accessRights "PUBLIC" ;
                    dcterms:identifier "FatMaxPressValRef" ;
                    skos:definition "Comentários Condições de teste dos tramos para - Máximo - FAT hidrostático"@pt-br ,
                                    "Specifies the reference pressure used to determine the FAT maximum pressure value."@en ;
                    skos:prefLabel "Factory Acceptance Test Maximum Pressure Value Reference"@en ,
                                   "Referência de Valor de Pressão Máxima para o Teste de Aceitação na Fábrica"@pt-br ;
-                   :hasAttributeScope :InstanceLevelAttribute ;
-                   :hasTypedValue :stringValue ;
-                   :hasValueCardinality :singleValue .
+                   edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                   edo:hasTypedValue edo:stringValue ;
+                   edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#FatMaxPressValRefMult
-:FatMaxPressValRefMult rdf:type owl:Class ;
-                       rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:FatMaxPressValRefMult rdf:type owl:Class ;
+                       rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
                        dcterms:accessRights "PUBLIC" ;
                        dcterms:identifier "FatMaxPressValRefMult" ;
                        skos:definition "The multiplier applied to the reference pressure to determine the FAT maximum pressure value."@en ;
                        skos:prefLabel "Factory Acceptance Test Maximum Pressure Value Reference Multiplier"@en ,
                                       "Multiplicador de Referência de Valor de Pressão Máxima para Teste de Aceitação na Fábrica"@pt-br ;
-                       :hasAttributeScope :InstanceLevelAttribute ;
-                       :hasTypedValue :floatValue ;
-                       :hasValueCardinality :singleValue .
+                       edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                       edo:hasTypedValue edo:floatValue ;
+                       edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#FatNomPress
-:FatNomPress rdf:type owl:Class ;
-             rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:FatNomPress rdf:type owl:Class ;
+             rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
              dcterms:accessRights "PUBLIC" ;
              dcterms:identifier "FatNomPress" ;
              skos:definition "Condições de teste dos tramos para Pressão - Nominal - FAT hidrostático"@pt-br ,
                              "The nominal pressure applied during the Factory Acceptance Test (FAT), simulating typical operating conditions to verify equipment performance."@en ;
              skos:prefLabel "Factory Acceptance Test Nominal Pressure"@en ,
                             "Pressão Nominal para o Teste de Aceitação na Fábrica"@pt-br ;
-             :hasAttributeScope :InstanceLevelAttribute ;
-             :hasTypedValue :floatValue ;
-             :hasValueCardinality :singleValue .
+             edo:hasAttributeScope edo:InstanceLevelAttribute ;
+             edo:hasTypedValue edo:floatValue ;
+             edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#FatNomPressValRef
-:FatNomPressValRef rdf:type owl:Class ;
-                   rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:FatNomPressValRef rdf:type owl:Class ;
+                   rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
                    dcterms:accessRights "PUBLIC" ;
                    dcterms:identifier "FatNomPressValRef" ;
                    skos:definition "Comentários Condições de teste dos tramos para - Nominal - FAT hidrostático"@pt-br ,
                                    "Specifies the reference pressure used to determine the FAT nominal pressure value."@en ;
                    skos:prefLabel "Factory Acceptance Test Nominal Pressure Value Reference"@en ,
                                   "Referência de Valor de Pressão Nominal para o Teste de Aceitação na Fábrica"@pt-br ;
-                   :hasAttributeScope :InstanceLevelAttribute ;
-                   :hasTypedValue :stringValue ;
-                   :hasValueCardinality :singleValue .
+                   edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                   edo:hasTypedValue edo:stringValue ;
+                   edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#FatNomPressValRefMult
-:FatNomPressValRefMult rdf:type owl:Class ;
-                       rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:FatNomPressValRefMult rdf:type owl:Class ;
+                       rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
                        dcterms:accessRights "PUBLIC" ;
                        dcterms:identifier "FatNomPressValRefMult" ;
                        skos:definition "The multiplier applied to the reference pressure to determine the FAT nominal pressure value."@en ;
                        skos:prefLabel "Factory Acceptance Test Nominal Pressure Value Reference Multiplier"@en ,
                                       "Multiplicador de Referência de Valor de Pressão Nominal para Teste de Aceitação na Fábrica"@pt-br ;
-                       :hasAttributeScope :InstanceLevelAttribute ;
-                       :hasTypedValue :floatValue ;
-                       :hasValueCardinality :singleValue .
+                       edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                       edo:hasTypedValue edo:floatValue ;
+                       edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#FiberOpticJumper
-:FiberOpticJumper rdf:type owl:Class ;
-                  rdfs:subClassOf :LinearObject ;
+edo:FiberOpticJumper rdf:type owl:Class ;
+                  rdfs:subClassOf edo:LinearObject ;
                   dcterms:identifier "FiberOpticJumper" .
 
 
 ###  https://w3id.org/energy-domain/edo#FiberRopeSegment
-:FiberRopeSegment rdf:type owl:Class ;
-                  rdfs:subClassOf :RopeSegment ;
+edo:FiberRopeSegment rdf:type owl:Class ;
+                  rdfs:subClassOf edo:RopeSegment ;
                   dcterms:identifier "FiberRopeSegment" .
 
 
 ###  https://w3id.org/energy-domain/edo#Filler
-:Filler rdf:type owl:Class ;
-        rdfs:subClassOf :UmbilicalComponent ;
+edo:Filler rdf:type owl:Class ;
+        rdfs:subClassOf edo:UmbilicalComponent ;
         dcterms:identifier "Filler" .
 
 
 ###  https://w3id.org/energy-domain/edo#FinancialAttribute
-:FinancialAttribute rdf:type owl:Class ;
-                    rdfs:subClassOf :AttributeDomainCategory ;
+edo:FinancialAttribute rdf:type owl:Class ;
+                    rdfs:subClassOf edo:AttributeDomainCategory ;
                     rdfs:comment "Represents costs, prices, depreciation."@en ;
                     rdfs:label "Atributo Financeiro"@pt-br ,
                                "Financial Attribute"@en ;
@@ -2084,40 +2083,40 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#FlangeAttribute
-:FlangeAttribute rdf:type owl:Class ;
-                 rdfs:subClassOf :DomainAttribute ;
+edo:FlangeAttribute rdf:type owl:Class ;
+                 rdfs:subClassOf edo:DomainAttribute ;
                  rdfs:label "Flange Attribute"@en .
 
 
 ###  https://w3id.org/energy-domain/edo#FlangeFaceType
-:FlangeFaceType rdf:type owl:Class ;
-                rdfs:subClassOf :FlangeAttribute ;
+edo:FlangeFaceType rdf:type owl:Class ;
+                rdfs:subClassOf edo:FlangeAttribute ;
                 dcterms:accessRights "PUBLIC" ;
                 dcterms:identifier "FlangeFaceType" ;
                 skos:definition "Specific design of the sealing surface used to ensure a secure, leak-tight connection. The face type plays a crucial role in maintaining the integrity of the seal under the extreme pressures and temperatures. It is engineered to prevent leaks, withstand high mechanical loads, and provide long-term durability. The appropriate face type is chosen based on factors such as pressure rating, sealing requirements, and environmental conditions."@en ;
                 skos:prefLabel "Flange Face Type"@en ,
                                "Tipo da Face do Flange"@pt-br ;
-                :hasAttributeScope :TypeLevelAttribute ;
-                :hasTypedValue :stringValue ;
-                :hasValueCardinality :singleValue .
+                edo:hasAttributeScope edo:TypeLevelAttribute ;
+                edo:hasTypedValue edo:stringValue ;
+                edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#FlangeType
-:FlangeType rdf:type owl:Class ;
-            rdfs:subClassOf :FlangeAttribute ;
+edo:FlangeType rdf:type owl:Class ;
+            rdfs:subClassOf edo:FlangeAttribute ;
             dcterms:accessRights "PUBLIC" ;
             dcterms:identifier "FlangeType" ;
             skos:definition "Specifies the type of flange within the Standard, which defines certain characteristics, like the Standard itself, Type or Class, Diameter and Operating Pressure."@en ;
             skos:prefLabel "Flange Type"@en ,
                            "Tipo de Flange"@pt-br ;
-            :hasAttributeScope :TypeLevelAttribute ;
-            :hasTypedValue :stringValue ;
-            :hasValueCardinality :singleValue .
+            edo:hasAttributeScope edo:TypeLevelAttribute ;
+            edo:hasTypedValue edo:stringValue ;
+            edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#FlexiblePipeSegment
-:FlexiblePipeSegment rdf:type owl:Class ;
-                     rdfs:subClassOf :PipeSegment ;
+edo:FlexiblePipeSegment rdf:type owl:Class ;
+                     rdfs:subClassOf edo:PipeSegment ;
                      dcterms:identifier "FlexiblePipeSegment" ;
                      skos:altLabel "Flexible Line Section"@en ,
                                    "Flexible Pipe Section"@en ,
@@ -2127,58 +2126,58 @@ rdf:value rdf:type owl:DatatypeProperty .
                                      "Um segmento de duto flexível que faz parte do sistema de pipeline geral. O Tramo Flexível é projetado para transportar fluidos ou gases por distâncias e condições variadas no fundo do mar. Cada seção é projetada para atender a requisitos ambientais e operacionais específicos, contribuindo para a flexibilidade, durabilidade e desempenho do sistema de dutos submarinos."@pt-br ;
                      skos:prefLabel "Flexible Pipe Segment"@en ,
                                     "Tramo de Duto Flexível"@pt-br ;
-                     :hasAttribute :AssemblyShouldObeyModelPolarity ,
-                                   :EarlyLeakMaxPressTable_Press ,
-                                   :EarlyLeakMaxPressTable_PressIntValStrat ,
-                                   :EarlyLeakMaxPressTable_PressValRef ,
-                                   :EarlyLeakMaxPressTable_PressValRefMult ,
-                                   :EarlyLeakMaxPressTable_TensLimit ,
-                                   :EarlyLeakMaxPressTable_TensLimitValRef ,
-                                   :EarlyLeakNomPressTable_Press ,
-                                   :EarlyLeakNomPressTable_PressIntValStrat ,
-                                   :EarlyLeakNomPressTable_PressValRef ,
-                                   :EarlyLeakNomPressTable_PressValRefMult ,
-                                   :EarlyLeakNomPressTable_TensLimit ,
-                                   :EarlyLeakNomPressTable_TensLimitValRef ,
-                                   :FatMaxPress ,
-                                   :FatMaxPressValRef ,
-                                   :FatMaxPressValRefMult ,
-                                   :FatNomPress ,
-                                   :FatNomPressValRef ,
-                                   :FatNomPressValRefMult ,
-                                   :IdInUnifilarDiagram ,
-                                   :ManufacturingDate ,
-                                   :ManufacturingNonConformities ,
-                                   :MaxLengthTolerance ,
-                                   :NominalLength ,
-                                   :OffLeakPLevMaxPress ,
-                                   :OffLeakPLevMaxPressValRef ,
-                                   :OffLeakPLevMaxPressValRefMult ,
-                                   :OffLeakPLevNomPress ,
-                                   :OffLeakPLevNomPressValRef ,
-                                   :OffLeakPLevNomPressValRefMult ,
-                                   :PipeSectionApplication ,
-                                   :SpecialRequirements ,
-                                   :StrIntOffPLevMaxPress ,
-                                   :StrIntOffPLevMaxPressValRef ,
-                                   :StrIntOffPLevMaxPressValRefMult ,
-                                   :StrIntOffPLevNomPress ,
-                                   :StrIntOffPLevNomPressValRef ,
-                                   :StrIntOffPLevNomPressValRefMult ,
-                                   :StrIntOnNoTensMaxPress ,
-                                   :StrIntOnNoTensMaxPressValRef ,
-                                   :StrIntOnNoTensMaxPressValRefMult ,
-                                   :StrIntOnNoTensNomPress ,
-                                   :StrIntOnNoTensNomPressValRef ,
-                                   :StrIntOnNoTensNomPressValRefMult ;
-                     :ifc_equivalentClass "IfcPipeSegment" ;
-                     :ifc_objectType "FlexiblePipeSegment" ;
-                     :ifc_predefinedType "USERDEFINED" .
+                     edo:hasAttribute edo:AssemblyShouldObeyModelPolarity ,
+                                   edo:EarlyLeakMaxPressTable_Press ,
+                                   edo:EarlyLeakMaxPressTable_PressIntValStrat ,
+                                   edo:EarlyLeakMaxPressTable_PressValRef ,
+                                   edo:EarlyLeakMaxPressTable_PressValRefMult ,
+                                   edo:EarlyLeakMaxPressTable_TensLimit ,
+                                   edo:EarlyLeakMaxPressTable_TensLimitValRef ,
+                                   edo:EarlyLeakNomPressTable_Press ,
+                                   edo:EarlyLeakNomPressTable_PressIntValStrat ,
+                                   edo:EarlyLeakNomPressTable_PressValRef ,
+                                   edo:EarlyLeakNomPressTable_PressValRefMult ,
+                                   edo:EarlyLeakNomPressTable_TensLimit ,
+                                   edo:EarlyLeakNomPressTable_TensLimitValRef ,
+                                   edo:FatMaxPress ,
+                                   edo:FatMaxPressValRef ,
+                                   edo:FatMaxPressValRefMult ,
+                                   edo:FatNomPress ,
+                                   edo:FatNomPressValRef ,
+                                   edo:FatNomPressValRefMult ,
+                                   edo:IdInUnifilarDiagram ,
+                                   edo:ManufacturingDate ,
+                                   edo:ManufacturingNonConformities ,
+                                   edo:MaxLengthTolerance ,
+                                   edo:NominalLength ,
+                                   edo:OffLeakPLevMaxPress ,
+                                   edo:OffLeakPLevMaxPressValRef ,
+                                   edo:OffLeakPLevMaxPressValRefMult ,
+                                   edo:OffLeakPLevNomPress ,
+                                   edo:OffLeakPLevNomPressValRef ,
+                                   edo:OffLeakPLevNomPressValRefMult ,
+                                   edo:PipeSectionApplication ,
+                                   edo:SpecialRequirements ,
+                                   edo:StrIntOffPLevMaxPress ,
+                                   edo:StrIntOffPLevMaxPressValRef ,
+                                   edo:StrIntOffPLevMaxPressValRefMult ,
+                                   edo:StrIntOffPLevNomPress ,
+                                   edo:StrIntOffPLevNomPressValRef ,
+                                   edo:StrIntOffPLevNomPressValRefMult ,
+                                   edo:StrIntOnNoTensMaxPress ,
+                                   edo:StrIntOnNoTensMaxPressValRef ,
+                                   edo:StrIntOnNoTensMaxPressValRefMult ,
+                                   edo:StrIntOnNoTensNomPress ,
+                                   edo:StrIntOnNoTensNomPressValRef ,
+                                   edo:StrIntOnNoTensNomPressValRefMult ;
+                     edo:ifc_equivalentClass "IfcPipeSegment" ;
+                     edo:ifc_objectType "FlexiblePipeSegment" ;
+                     edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#FlexiblePipeStructure
-:FlexiblePipeStructure rdf:type owl:Class ;
-                       rdfs:subClassOf :DomainElement ;
+edo:FlexiblePipeStructure rdf:type owl:Class ;
+                       rdfs:subClassOf edo:DomainElement ;
                        dcterms:identifier "FlexiblePipeStructure" ;
                        skos:altLabel "Flexible Structure"@en ,
                                      "Subsea Flexible Configuration"@en ,
@@ -2187,121 +2186,121 @@ rdf:value rdf:type owl:DatatypeProperty .
                                        "The Flexible Pipe Structure is the layered configuration of a flexible pipe, designed to provide flexibility and strength in subsea environments. It consists of multiple layers, each serving a specific function, such as pressure containment, protection, or reinforcement. This structure is engineered to handle the demands of deepwater conditions, including high pressure and dynamic movements, ensuring the pipe's integrity and performance."@en ;
                        skos:prefLabel "Estrutura de Duto Flexível"@pt-br ,
                                       "Flexible Pipe Structure"@en ;
-                       :hasAttribute :AbsoluteInsidePressure ,
-                                     :AbsoluteOutsidePressure ,
-                                     :AxialStiffnessUnderCompressionAtSeaLevel ,
-                                     :AxialStiffnessUnderTensionAtSeaLevel ,
-                                     :BendingMomentTable_BendingMoment ,
-                                     :BendingMomentTable_Curvature ,
-                                     :CalculatedAbsoluteBurstPressure ,
-                                     :CriticalCurvatureOfSlipping ,
-                                     :DamagingPullInStraightLine ,
-                                     :DimensioningCriteria ,
-                                     :ErosionalVelocity ,
-                                     :FlexibleStructureServicesList ,
-                                     :FrictionCoefBetweenPipeAndTensioner ,
-                                     :FrictionCoefficientTighteningTable_CoefficientOfFriction ,
-                                     :FrictionCoefficientTighteningTable_TighteningPerTrack ,
-                                     :HydrostaticCollapseAbsPressDry ,
-                                     :InsideTemperature ,
-                                     :IntermediateValuesStrategy ,
-                                     :InternalDiameter ,
-                                     :LayingMinimumRadiusTable_AbsoluteExternalPressure ,
-                                     :LayingMinimumRadiusTable_AbsoluteInternalPressure ,
-                                     :LayingMinimumRadiusTable_Compression ,
-                                     :LayingMinimumRadiusTable_MinimumAllowableBendingRadius ,
-                                     :LayingMinimumRadiusTable_SectionSupportedByRigidSupport ,
-                                     :LayingMinimumRadiusTable_TensileArmourAnnulusCondition ,
-                                     :LimpTorsionalStiffnessAtSeaLevel ,
-                                     :LinearMass ,
-                                     :MaxDesignPressure ,
-                                     :MaximumAllowableTensileForStraightLine ,
-                                     :MaximumAllowableTensionTable_MaximumAllowableTensile ,
-                                     :MaximumAllowableTensionTable_PulleyRadius ,
-                                     :MaximumAllowableTensionTable_PulleyVAngle ,
-                                     :MaximumAllowableTighteningTable_AxialLoad ,
-                                     :MaximumAllowableTighteningTable_TighteningPerTrack ,
-                                     :MaximumAmbientTemperature ,
-                                     :MinimumBendingRadiusForStorage ,
-                                     :OuterDiameter ,
-                                     :OutsideTemperature ,
-                                     :PostSlippingBendingStiffness ,
-                                     :PreSlippingBendingStiffness ,
-                                     :SpoolingTension ,
-                                     :StiffTorsionalStiffnessAtSeaLevel ,
-                                     :StructureApplicationsList ,
-                                     :StructureCode ,
-                                     :TensileArmourAnnulusCondition ,
-                                     :TensileArmourFreeAnnulusVolume ,
-                                     :TensionerPadsMaterial ,
-                                     :TensionerPadsOpeningAngle ,
-                                     :TensionerPadsShape ,
-                                     :TensionerTracksQuantity ,
-                                     :TestConditions ,
-                                     :ThermalExchangeCoefficientFlooded ,
-                                     :UtilizationFactor ;
-                       :ifc_equivalentClass "IfcPipeSegmentType" ;
-                       :ifc_objectType "FlexiblePipeStructure" ;
-                       :ifc_predefinedType "USERDEFINED" .
+                       edo:hasAttribute edo:AbsoluteInsidePressure ,
+                                     edo:AbsoluteOutsidePressure ,
+                                     edo:AxialStiffnessUnderCompressionAtSeaLevel ,
+                                     edo:AxialStiffnessUnderTensionAtSeaLevel ,
+                                     edo:BendingMomentTable_BendingMoment ,
+                                     edo:BendingMomentTable_Curvature ,
+                                     edo:CalculatedAbsoluteBurstPressure ,
+                                     edo:CriticalCurvatureOfSlipping ,
+                                     edo:DamagingPullInStraightLine ,
+                                     edo:DimensioningCriteria ,
+                                     edo:ErosionalVelocity ,
+                                     edo:FlexibleStructureServicesList ,
+                                     edo:FrictionCoefBetweenPipeAndTensioner ,
+                                     edo:FrictionCoefficientTighteningTable_CoefficientOfFriction ,
+                                     edo:FrictionCoefficientTighteningTable_TighteningPerTrack ,
+                                     edo:HydrostaticCollapseAbsPressDry ,
+                                     edo:InsideTemperature ,
+                                     edo:IntermediateValuesStrategy ,
+                                     edo:InternalDiameter ,
+                                     edo:LayingMinimumRadiusTable_AbsoluteExternalPressure ,
+                                     edo:LayingMinimumRadiusTable_AbsoluteInternalPressure ,
+                                     edo:LayingMinimumRadiusTable_Compression ,
+                                     edo:LayingMinimumRadiusTable_MinimumAllowableBendingRadius ,
+                                     edo:LayingMinimumRadiusTable_SectionSupportedByRigidSupport ,
+                                     edo:LayingMinimumRadiusTable_TensileArmourAnnulusCondition ,
+                                     edo:LimpTorsionalStiffnessAtSeaLevel ,
+                                     edo:LinearMass ,
+                                     edo:MaxDesignPressure ,
+                                     edo:MaximumAllowableTensileForStraightLine ,
+                                     edo:MaximumAllowableTensionTable_MaximumAllowableTensile ,
+                                     edo:MaximumAllowableTensionTable_PulleyRadius ,
+                                     edo:MaximumAllowableTensionTable_PulleyVAngle ,
+                                     edo:MaximumAllowableTighteningTable_AxialLoad ,
+                                     edo:MaximumAllowableTighteningTable_TighteningPerTrack ,
+                                     edo:MaximumAmbientTemperature ,
+                                     edo:MinimumBendingRadiusForStorage ,
+                                     edo:OuterDiameter ,
+                                     edo:OutsideTemperature ,
+                                     edo:PostSlippingBendingStiffness ,
+                                     edo:PreSlippingBendingStiffness ,
+                                     edo:SpoolingTension ,
+                                     edo:StiffTorsionalStiffnessAtSeaLevel ,
+                                     edo:StructureApplicationsList ,
+                                     edo:StructureCode ,
+                                     edo:TensileArmourAnnulusCondition ,
+                                     edo:TensileArmourFreeAnnulusVolume ,
+                                     edo:TensionerPadsMaterial ,
+                                     edo:TensionerPadsOpeningAngle ,
+                                     edo:TensionerPadsShape ,
+                                     edo:TensionerTracksQuantity ,
+                                     edo:TestConditions ,
+                                     edo:ThermalExchangeCoefficientFlooded ,
+                                     edo:UtilizationFactor ;
+                       edo:ifc_equivalentClass "IfcPipeSegmentType" ;
+                       edo:ifc_objectType "FlexiblePipeStructure" ;
+                       edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#FlexibleStructureLayer
-:FlexibleStructureLayer rdf:type owl:Class ;
-                        rdfs:subClassOf :DomainElement ;
+edo:FlexibleStructureLayer rdf:type owl:Class ;
+                        rdfs:subClassOf edo:DomainElement ;
                         dcterms:identifier "FlexibleStructureLayer" ;
                         skos:definition "A specific layer within the structure of a subsea flexible pipe, each designed to fulfill a distinct function. These layers work together to provide essential properties such as pressure containment, reinforcement, and environmental protection. Engineered to withstand harsh underwater conditions, each layer contributes to the overall flexibility, durability, and performance of the subsea flexible pipe system."@en ;
                         skos:prefLabel "Camadas de Estruturas Flexíveis"@pt-br ,
                                        "Flexible Structure Layer"@en ;
-                        :hasAttribute :InternalDiameter ,
-                                      :LayerAnnular ,
-                                      :LayerAnnularType ,
-                                      :LayerContinuity ,
-                                      :LayerGeometryCrossSection ,
-                                      :LayerGeometryInertiaX ,
-                                      :LayerGeometryInertiaY ,
-                                      :LayerGeometryManufacturer ,
-                                      :LayerGeometryName ,
-                                      :LayerGeometryProfileThickness ,
-                                      :LayerGeometryProfileWidth ,
-                                      :LayerGeometryThickness ,
-                                      :LayerThickness ,
-                                      :LayerWatertight ,
-                                      :LayerWatertightLowerLayerInternalFreeVolume ,
-                                      :LinearMass .
+                        edo:hasAttribute edo:InternalDiameter ,
+                                      edo:LayerAnnular ,
+                                      edo:LayerAnnularType ,
+                                      edo:LayerContinuity ,
+                                      edo:LayerGeometryCrossSection ,
+                                      edo:LayerGeometryInertiaX ,
+                                      edo:LayerGeometryInertiaY ,
+                                      edo:LayerGeometryManufacturer ,
+                                      edo:LayerGeometryName ,
+                                      edo:LayerGeometryProfileThickness ,
+                                      edo:LayerGeometryProfileWidth ,
+                                      edo:LayerGeometryThickness ,
+                                      edo:LayerThickness ,
+                                      edo:LayerWatertight ,
+                                      edo:LayerWatertightLowerLayerInternalFreeVolume ,
+                                      edo:LinearMass .
 
 
 ###  https://w3id.org/energy-domain/edo#FlexibleStructureLayerMaterial
-:FlexibleStructureLayerMaterial rdf:type owl:Class ;
-                                rdfs:subClassOf :DomainElement ;
+edo:FlexibleStructureLayerMaterial rdf:type owl:Class ;
+                                rdfs:subClassOf edo:DomainElement ;
                                 dcterms:identifier "FlexibleStructureLayerMaterial" ;
                                 skos:definition "Material used to fabricate the individual layers of a subsea flexible structure, each layer serving a distinct function such as pressure containment, tensile reinforcement, or external protection. The Flexible Structure Layer Material is selected based on its specific properties, such as strength, flexibility, corrosion resistance, or thermal insulation, to ensure the overall performance and durability of the flexible pipe in harsh subsea conditions. These materials may include polymers, metals, composites, or other high-performance substances tailored to the pipe's operational demands."@en ;
                                 skos:prefLabel "Flexible Structure Layer Material"@en ,
                                                "Materiais de Camadas de Estruturas Flexíveis Submarinas"@pt-br ;
-                                :hasAttribute :ElasticityModulusAt23Degrees ,
-                                              :MaterialComposition ,
-                                              :PoissonRatioAt23Degrees ,
-                                              :SpecificHeatCapacity ,
-                                              :SpecificWeight ,
-                                              :TechnicalNotes ,
-                                              :ThermalConductivityCoefficient .
+                                edo:hasAttribute edo:ElasticityModulusAt23Degrees ,
+                                              edo:MaterialComposition ,
+                                              edo:PoissonRatioAt23Degrees ,
+                                              edo:SpecificHeatCapacity ,
+                                              edo:SpecificWeight ,
+                                              edo:TechnicalNotes ,
+                                              edo:ThermalConductivityCoefficient .
 
 
 ###  https://w3id.org/energy-domain/edo#FlexibleStructureServicesList
-:FlexibleStructureServicesList rdf:type owl:Class ;
-                               rdfs:subClassOf :DomainAttribute ;
+edo:FlexibleStructureServicesList rdf:type owl:Class ;
+                               rdfs:subClassOf edo:DomainAttribute ;
                                dcterms:accessRights "PUBLIC" ;
                                dcterms:identifier "FlexibleStructureServicesList" ;
                                skos:definition "Indicates the list of services that the flexible structure is capable of performing as part of a flexible pipeline. Multiple values can be selected, defining the operational roles the structure is designed to execute."@en ;
                                skos:prefLabel "Flexible Structure Services List"@en ,
                                               "Lista de Serviços da Estrutura Flexível"@pt-br ;
-                               :hasAttributeScope :TypeLevelAttribute ;
-                               :hasTypedValue :stringValue ;
-                               :hasValueCardinality :multiValue .
+                               edo:hasAttributeScope edo:TypeLevelAttribute ;
+                               edo:hasTypedValue edo:stringValue ;
+                               edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#FloatingProductionUnit
-:FloatingProductionUnit rdf:type owl:Class ;
-                        rdfs:subClassOf :Location ;
+edo:FloatingProductionUnit rdf:type owl:Class ;
+                        rdfs:subClassOf edo:Location ;
                         dcterms:identifier "FloatingProductionUnit" ;
                         skos:altLabel "FLNG"@en ,
                                       "FPSO"@en ,
@@ -2312,133 +2311,133 @@ rdf:value rdf:type owl:DatatypeProperty .
                                         "Plataforma offshore usada na exploração e produção de petróleo e gás, projetada para extrair, processar e armazenar hidrocarbonetos. A Unidade de Produção Flutuante (FPU) é ancorada ou amarrada ao leito marinho e pode operar em águas profundas, frequentemente conectada a poços submarinos por meio de dutos flexíveis e umbilicais. Ela acomoda equipamentos de processamento para separação de petróleo, gás e água, bem como instalações para armazenamento temporário ou transferência de hidrocarbonetos processados para navios-tanque ou dutos. As FPUs são essenciais para a produção eficiente e segura de petróleo e gás em ambientes offshore desafiadores."@pt-br ;
                         skos:prefLabel "Floating Production Unit"@en ,
                                        "Unidade de Produção Flutuante (UEP)"@pt-br ;
-                        :ifc_equivalentClass "IfcBuilding" ;
-                        :ifc_objectType "FloatingProductionUnit" ;
-                        :ifc_predefinedType "USERDEFINED" .
+                        edo:ifc_equivalentClass "IfcBuilding" ;
+                        edo:ifc_objectType "FloatingProductionUnit" ;
+                        edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#FlowBase
-:FlowBase rdf:type owl:Class ;
-          rdfs:subClassOf :FlowControlEquipment ;
+edo:FlowBase rdf:type owl:Class ;
+          rdfs:subClassOf edo:FlowControlEquipment ;
           dcterms:identifier "FlowBase" .
 
 
 ###  https://w3id.org/energy-domain/edo#FlowConnector
-:FlowConnector rdf:type owl:Class ;
-               rdfs:subClassOf :PressureComponent ;
+edo:FlowConnector rdf:type owl:Class ;
+               rdfs:subClassOf edo:PressureComponent ;
                dcterms:identifier "FlowConnector" .
 
 
 ###  https://w3id.org/energy-domain/edo#FlowControlEquipment
-:FlowControlEquipment rdf:type owl:Class ;
-                      rdfs:subClassOf :PressureEquipment ;
+edo:FlowControlEquipment rdf:type owl:Class ;
+                      rdfs:subClassOf edo:PressureEquipment ;
                       dcterms:identifier "FlowControlEquipment" ;
-                      :hasAttribute :HasThermalInsulation ,
-                                    :NumberOfChokeValves ,
-                                    :NumberOfRemoteProcessIsolationValves ,
-                                    :Piggable .
+                      edo:hasAttribute edo:HasThermalInsulation ,
+                                    edo:NumberOfChokeValves ,
+                                    edo:NumberOfRemoteProcessIsolationValves ,
+                                    edo:Piggable .
 
 
 ###  https://w3id.org/energy-domain/edo#FlowControlModule
-:FlowControlModule rdf:type owl:Class ;
-                   rdfs:subClassOf :FlowControlEquipment ;
+edo:FlowControlModule rdf:type owl:Class ;
+                   rdfs:subClassOf edo:FlowControlEquipment ;
                    dcterms:identifier "FlowControlModule" .
 
 
 ###  https://w3id.org/energy-domain/edo#FlowLineMandrel
-:FlowLineMandrel rdf:type owl:Class ;
-                 rdfs:subClassOf :TieInEquipment ;
+edo:FlowLineMandrel rdf:type owl:Class ;
+                 rdfs:subClassOf edo:TieInEquipment ;
                  dcterms:identifier "FlowLineMandrel" .
 
 
 ###  https://w3id.org/energy-domain/edo#FlowbaseRunningTool
-:FlowbaseRunningTool rdf:type owl:Class ;
-                     rdfs:subClassOf :RunningTool ;
+edo:FlowbaseRunningTool rdf:type owl:Class ;
+                     rdfs:subClassOf edo:RunningTool ;
                      dcterms:identifier "FlowbaseRunningTool" .
 
 
 ###  https://w3id.org/energy-domain/edo#FlowlineSpan
-:FlowlineSpan rdf:type owl:Class ;
-              rdfs:subClassOf :PipelineSpan ;
+edo:FlowlineSpan rdf:type owl:Class ;
+              rdfs:subClassOf edo:PipelineSpan ;
               dcterms:identifier "FlowlineSpan" .
 
 
 ###  https://w3id.org/energy-domain/edo#FractureToughness
-:FractureToughness rdf:type owl:Class ;
-                   rdfs:subClassOf :DomainAttribute ;
+edo:FractureToughness rdf:type owl:Class ;
+                   rdfs:subClassOf edo:DomainAttribute ;
                    dcterms:accessRights "PUBLIC" ;
                    dcterms:identifier "FractureToughness" ;
                    skos:definition "Represents the material's ability to resist fracture when subjected to stress, particularly in the presence of flaws or cracks. This property is essential for assessing the material's capacity to withstand cracking or failure under load conditions."@en ,
                                    "Tenacidade à fratura (Específica para Materiais Metálicos)"@pt-br ;
                    skos:prefLabel "Fracture Toughness"@en ,
                                   "Tenacidade à Fratura"@pt-br ;
-                   :hasAttributeScope :TypeLevelAttribute ;
-                   :hasTypedValue :floatValue ;
-                   :hasValueCardinality :singleValue .
+                   edo:hasAttributeScope edo:TypeLevelAttribute ;
+                   edo:hasTypedValue edo:floatValue ;
+                   edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#FrictionCoefBetweenPipeAndTensioner
-:FrictionCoefBetweenPipeAndTensioner rdf:type owl:Class ;
-                                     rdfs:subClassOf :DomainAttribute ;
+edo:FrictionCoefBetweenPipeAndTensioner rdf:type owl:Class ;
+                                     rdfs:subClassOf edo:DomainAttribute ;
                                      dcterms:accessRights "PUBLIC" ;
                                      dcterms:identifier "FrictionCoefBetweenPipeAndTensioner" ;
                                      skos:definition "Coeficiente de atrito entre a sapata e a capa externa (passagem tensionador)"@pt-br ,
                                                      "Represents the coefficient of friction between the pipe and the tensioner during installation or operation. This property is critical for determining the resistance to sliding between the two surfaces, influencing the tension control and handling of the pipe."@en ;
                                      skos:prefLabel "Coeficiente de Atrito entre o Duto e o Tensionador"@pt-br ,
                                                     "Friction Coefficient Between Pipe And Tensioner"@en ;
-                                     :hasAttributeScope :TypeLevelAttribute ;
-                                     :hasTypedValue :floatValue ;
-                                     :hasValueCardinality :singleValue .
+                                     edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                     edo:hasTypedValue edo:floatValue ;
+                                     edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#FrictionCoefficientTighteningTable_CoefficientOfFriction
-:FrictionCoefficientTighteningTable_CoefficientOfFriction rdf:type owl:Class ;
-                                                          rdfs:subClassOf :CrushingFrictionCoefficientTighteningTableColumn ;
+edo:FrictionCoefficientTighteningTable_CoefficientOfFriction rdf:type owl:Class ;
+                                                          rdfs:subClassOf edo:CrushingFrictionCoefficientTighteningTableColumn ;
                                                           dcterms:accessRights "PUBLIC" ;
                                                           dcterms:identifier "FrictionCoefficientTighteningTable_CoefficientOfFriction" ;
                                                           skos:definition "Represents the ratio that describes the force of friction between two surfaces in contact, relative to the normal force pressing them together. This property is important for evaluating the resistance to sliding or movement, ensuring proper performance of components under operational conditions."@en ;
                                                           skos:prefLabel "Coefficient Of Friction"@en ,
                                                                          "Coeficiente de Atrito"@pt-br ;
-                                                          :hasAttributeScope :TypeLevelAttribute ;
-                                                          :hasTypedValue :floatValue ;
-                                                          :hasValueCardinality :multiValue .
+                                                          edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                                          edo:hasTypedValue edo:floatValue ;
+                                                          edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#FrictionCoefficientTighteningTable_TighteningPerTrack
-:FrictionCoefficientTighteningTable_TighteningPerTrack rdf:type owl:Class ;
-                                                       rdfs:subClassOf :CrushingFrictionCoefficientTighteningTableColumn ;
+edo:FrictionCoefficientTighteningTable_TighteningPerTrack rdf:type owl:Class ;
+                                                       rdfs:subClassOf edo:CrushingFrictionCoefficientTighteningTableColumn ;
                                                        dcterms:accessRights "PUBLIC" ;
                                                        dcterms:identifier "FrictionCoefficientTighteningTable_TighteningPerTrack" ;
                                                        skos:definition "Indicates the amount of tightening applied per track during an operation. This property is important for ensuring consistent force distribution across multiple tracks, helping to maintain proper alignment and secure attachment during the tightening process."@en ;
                                                        skos:prefLabel "Aperto por lagarta"@pt-br ,
                                                                       "Tightening Per Track"@en ;
-                                                       :hasAttributeScope :TypeLevelAttribute ;
-                                                       :hasTypedValue :floatValue ;
-                                                       :hasValueCardinality :multiValue .
+                                                       edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                                       edo:hasTypedValue edo:floatValue ;
+                                                       edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#FullyThreaded
-:FullyThreaded rdf:type owl:Class ;
-               rdfs:subClassOf :DomainAttribute ;
+edo:FullyThreaded rdf:type owl:Class ;
+               rdfs:subClassOf edo:DomainAttribute ;
                dcterms:accessRights "PUBLIC" ;
                dcterms:identifier "FullyThreaded" ;
                skos:definition "Indicates whether the component will be used fully threaded (TRUE) or not (FALSE)."@en ;
                skos:prefLabel "Completamente Rosqueado"@pt-br ,
                               "Fully Threaded"@en ;
-               :hasAttributeScope :InstanceLevelAttribute ;
-               :hasTypedValue :booleanValue ;
-               :hasValueCardinality :singleValue .
+               edo:hasAttributeScope edo:InstanceLevelAttribute ;
+               edo:hasTypedValue edo:booleanValue ;
+               edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#FunctionLine
-:FunctionLine rdf:type owl:Class ;
-              rdfs:subClassOf :UmbilicalComponent ;
+edo:FunctionLine rdf:type owl:Class ;
+              rdfs:subClassOf edo:UmbilicalComponent ;
               dcterms:identifier "FunctionLine" .
 
 
 ###  https://w3id.org/energy-domain/edo#FunctionalAttribute
-:FunctionalAttribute rdf:type owl:Class ;
-                     rdfs:subClassOf :AttributeDomainCategory ;
+edo:FunctionalAttribute rdf:type owl:Class ;
+                     rdfs:subClassOf edo:AttributeDomainCategory ;
                      rdfs:comment "Describes how the equipment functions or performs its intended purpose."@en ;
                      rdfs:label "Atributo Funcional"@pt-br ,
                                 "Functional Attribute"@en ;
@@ -2447,21 +2446,21 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#GalvanicMaterial
-:GalvanicMaterial rdf:type owl:Class ;
-                  rdfs:subClassOf :DomainAttribute ;
+edo:GalvanicMaterial rdf:type owl:Class ;
+                  rdfs:subClassOf edo:DomainAttribute ;
                   dcterms:accessRights "PUBLIC" ;
                   dcterms:identifier "GalvanicMaterial" ;
                   skos:definition "Refers to the material used in galvanic protection systems, which is typically a metal or alloy designed to corrode in place of the protected structure. This material is selected for its ability to act as a sacrificial anode in a galvanic cell, thereby preventing corrosion of the primary structure, such as a subsea flexible pipeline. The choice of galvanic material is critical for the long-term protection and integrity of the pipeline system."@en ;
                   skos:prefLabel "Galvanic Material"@en ,
                                  "Material Galvânico"@pt-br ;
-                  :hasAttributeScope :TypeLevelAttribute ;
-                  :hasTypedValue :stringValue ;
-                  :hasValueCardinality :singleValue .
+                  edo:hasAttributeScope edo:TypeLevelAttribute ;
+                  edo:hasTypedValue edo:stringValue ;
+                  edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#Geothermal
-:Geothermal rdf:type owl:Class ;
-            rdfs:subClassOf :Renewable ;
+edo:Geothermal rdf:type owl:Class ;
+            rdfs:subClassOf edo:Renewable ;
             rdfs:label "Energia Geotérmica"@pt-br ,
                        "Geothermal Energy"@en ;
             skos:definition "Energia derivada do calor armazenado abaixo da superfície da Terra."@pt-br ,
@@ -2469,157 +2468,157 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#GrooveDiameter
-:GrooveDiameter rdf:type owl:Class ;
-                rdfs:subClassOf :DomainAttribute ;
+edo:GrooveDiameter rdf:type owl:Class ;
+                rdfs:subClassOf edo:DomainAttribute ;
                 dcterms:accessRights "PUBLIC" ;
                 dcterms:identifier "GrooveDiameter" ;
                 skos:definition "Specifies the diameter of the end fitting at the location where the groove is machined. This measurement is crucial for ensuring that the groove correctly accommodates the end fitting during installation on a vessel. The part diameter at the groove location ensures proper alignment and secure attachment of the end fitting to the installation equipment or support system."@en ;
                 skos:prefLabel "Diâmetro do Groove"@pt-br ,
                                "Groove Diameter"@en ;
-                :hasAttributeScope :InstanceLevelAttribute ;
-                :hasTypedValue :floatValue ;
-                :hasValueCardinality :singleValue .
+                edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                edo:hasTypedValue edo:floatValue ;
+                edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#GrooveHeight
-:GrooveHeight rdf:type owl:Class ;
-              rdfs:subClassOf :DomainAttribute ;
+edo:GrooveHeight rdf:type owl:Class ;
+              rdfs:subClassOf edo:DomainAttribute ;
               dcterms:accessRights "PUBLIC" ;
               dcterms:identifier "GrooveHeight" ;
               skos:definition "Specifies the vertical dimension of the groove from its base to the top edge. This measurement is crucial for ensuring that the groove can accommodate the intended components or fittings properly, allowing for a secure and precise fit. The groove height helps to determine the correct depth and functionality of the groove in relation to the end fitting and the overall installation process."@en ;
               skos:prefLabel "Altura do Groove"@pt-br ,
                              "Groove Height"@en ;
-              :hasAttributeScope :InstanceLevelAttribute ;
-              :hasTypedValue :floatValue ;
-              :hasValueCardinality :singleValue .
+              edo:hasAttributeScope edo:InstanceLevelAttribute ;
+              edo:hasTypedValue edo:floatValue ;
+              edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#GrooveMinimumSupportArea
-:GrooveMinimumSupportArea rdf:type owl:Class ;
-                          rdfs:subClassOf :DomainAttribute ;
+edo:GrooveMinimumSupportArea rdf:type owl:Class ;
+                          rdfs:subClassOf edo:DomainAttribute ;
                           dcterms:accessRights "PUBLIC" ;
                           dcterms:identifier "GrooveMinimumSupportArea" ;
                           skos:definition "Specifies the minimum required area of the support surface within the groove. This measurement is crucial for ensuring that the groove provides adequate support and stability for the components or fittings it interfaces with. A sufficient support area helps prevent misalignment and ensures that the components are securely held in place during operation and installation."@en ;
                           skos:prefLabel "Groove Minimum Support Area"@en ,
                                          "Área Mínima de Apoio no Groove"@pt-br ;
-                          :hasAttributeScope :InstanceLevelAttribute ;
-                          :hasTypedValue :floatValue ;
-                          :hasValueCardinality :singleValue .
+                          edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                          edo:hasTypedValue edo:floatValue ;
+                          edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#GroovePoint
-:GroovePoint rdf:type owl:Class ;
-             rdfs:subClassOf :SupportRegion ;
+edo:GroovePoint rdf:type owl:Class ;
+             rdfs:subClassOf edo:SupportRegion ;
              dcterms:identifier "GroovePoint" ;
              skos:definition "Ponto na linha de centro do End Fitting para indicar a posição do Groove"@pt-br ,
                              "The Groove Point is a designated point on the center line of the End Fitting, used to indicate the exact position of a groove. The groove itself is a recessed area designed specifically to lock the End Fitting during onboard installation, ensuring that it remains securely in place during the process. The Groove Support Point provides a reference for locating the groove, facilitating the precise alignment and positioning required for a smooth installation."@en ;
              skos:prefLabel "Groove Point"@en ,
                             "Ponto de Groove"@pt-br ;
-             :hasAttribute :GrooveDiameter ,
-                           :GrooveHeight ,
-                           :GrooveMinimumSupportArea ,
-                           :GrooveSupportSurfaceDiameter ,
-                           :GrooveSupportSurfaceFilletRadius ,
-                           :GrvCntrPntDstnceFrmTermFlange ,
-                           :SafeWorkingLoad ,
-                           :TechnicalNotes ;
-             :ifc_equivalentClass "IfcDistributionPort" ;
-             :ifc_objectType "GroovePoint" ;
-             :ifc_predefinedType "USERDEFINED" .
+             edo:hasAttribute edo:GrooveDiameter ,
+                           edo:GrooveHeight ,
+                           edo:GrooveMinimumSupportArea ,
+                           edo:GrooveSupportSurfaceDiameter ,
+                           edo:GrooveSupportSurfaceFilletRadius ,
+                           edo:GrvCntrPntDstnceFrmTermFlange ,
+                           edo:SafeWorkingLoad ,
+                           edo:TechnicalNotes ;
+             edo:ifc_equivalentClass "IfcDistributionPort" ;
+             edo:ifc_objectType "GroovePoint" ;
+             edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#GrooveSupportSurfaceDiameter
-:GrooveSupportSurfaceDiameter rdf:type owl:Class ;
-                              rdfs:subClassOf :DomainAttribute ;
+edo:GrooveSupportSurfaceDiameter rdf:type owl:Class ;
+                              rdfs:subClassOf edo:DomainAttribute ;
                               dcterms:accessRights "PUBLIC" ;
                               dcterms:identifier "GrooveSupportSurfaceDiameter" ;
                               skos:definition "Indicates the diameter of the support surface within the groove. This measurement is critical for ensuring that the groove provides sufficient contact area for the components it interfaces with, contributing to a stable and secure fit."@en ;
                               skos:prefLabel "Diâmetro da superfície de apoio do acessório"@pt-br ,
                                              "Groove Support Surface Diameter"@en ;
-                              :hasAttributeScope :InstanceLevelAttribute ;
-                              :hasTypedValue :floatValue ;
-                              :hasValueCardinality :singleValue .
+                              edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                              edo:hasTypedValue edo:floatValue ;
+                              edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#GrooveSupportSurfaceFilletRadius
-:GrooveSupportSurfaceFilletRadius rdf:type owl:Class ;
-                                  rdfs:subClassOf :DomainAttribute ;
+edo:GrooveSupportSurfaceFilletRadius rdf:type owl:Class ;
+                                  rdfs:subClassOf edo:DomainAttribute ;
                                   dcterms:accessRights "PUBLIC" ;
                                   dcterms:identifier "GrooveSupportSurfaceFilletRadius" ;
                                   skos:definition "Adoçamento (Superfície de apoio) do acessório"@pt-br ,
                                                   "Indicates the radius of the fillet on the support surface of the end fitting. This fillet is a rounded corner or edge designed to reduce stress concentrations and enhance the structural integrity of the connection. The radius measurement is crucial for ensuring that the end fitting aligns properly with other components and provides a smooth, stable interface."@en ;
                                   skos:prefLabel "Groove Support Surface Fillet Radius"@en ,
                                                  "Raio de Chanframento (Superfície de Apoio) do Acessório"@pt-br ;
-                                  :hasAttributeScope :InstanceLevelAttribute ;
-                                  :hasTypedValue :floatValue ;
-                                  :hasValueCardinality :singleValue .
+                                  edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                  edo:hasTypedValue edo:floatValue ;
+                                  edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#GroutBag
-:GroutBag rdf:type owl:Class ;
-          rdfs:subClassOf :PipeSupport ;
+edo:GroutBag rdf:type owl:Class ;
+          rdfs:subClassOf edo:PipeSupport ;
           dcterms:identifier "GroutBag" .
 
 
 ###  https://w3id.org/energy-domain/edo#GrvCntrPntDstnceFrmTermFlange
-:GrvCntrPntDstnceFrmTermFlange rdf:type owl:Class ;
-                               rdfs:subClassOf :DomainAttribute ;
+edo:GrvCntrPntDstnceFrmTermFlange rdf:type owl:Class ;
+                               rdfs:subClassOf edo:DomainAttribute ;
                                dcterms:accessRights "PUBLIC" ;
                                dcterms:identifier "GrvCntrPntDstnceFrmTermFlange" ;
                                skos:definition "Distance from the center of the groove to the outer edge of the termination flange, the flange where the other end fitting is connected. This measurement provides the position of the groove relative to the termination flange for precise identification of a specific groove within the end fitting"@en ,
                                                "Distância do centro do groove até a borda externa do flange de terminação, o flange onde o outro end fitting é conectado. Esta medição fornece a posição do groove em relação ao flange para a identificação precisa de um groove específico dentro do end fitting."@pt-br ;
                                skos:prefLabel "Distância do Ponto Central do Groove até o Flange de Terminação"@pt-br ,
                                               "Groove Center Point Distance From Termination Flange"@en ;
-                               :hasAttributeScope :InstanceLevelAttribute ;
-                               :hasTypedValue :floatValue ;
-                               :hasValueCardinality :singleValue .
+                               edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                               edo:hasTypedValue edo:floatValue ;
+                               edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#GuideBase
-:GuideBase rdf:type owl:Class ;
-           rdfs:subClassOf :Structure ;
+edo:GuideBase rdf:type owl:Class ;
+           rdfs:subClassOf edo:Structure ;
            dcterms:identifier "GuideBase" .
 
 
 ###  https://w3id.org/energy-domain/edo#H2SVolumeConcentration
-:H2SVolumeConcentration rdf:type owl:Class ;
-                        rdfs:subClassOf :DomainAttribute ;
+edo:H2SVolumeConcentration rdf:type owl:Class ;
+                        rdfs:subClassOf edo:DomainAttribute ;
                         dcterms:accessRights "PUBLIC" ;
                         dcterms:identifier "H2SVolumeConcentration" ;
                         skos:definition "Represents the concentration of hydrogen sulfide (H2S) in the total volume of the gas mixture, expressed in parts per million by volume (ppmv). This value is crucial for assessing material compatibility and corrosion risks in subsea flexible pipelines, as H2S is highly corrosive and can significantly impact the integrity and lifespan of the pipeline. Accurate measurement of H2S concentration is essential for ensuring the safe and reliable operation of the pipeline in harsh environments."@en ;
                         skos:prefLabel "Concentração Volumétrica de Sulfeto de Hidrogênio (H2S)"@pt-br ,
                                        "Hydrogen Sulfide (H2S) Volume Concentration"@en ;
-                        :hasAttributeScope :InstanceLevelAttribute ;
-                        :hasTypedValue :floatValue ;
-                        :hasValueCardinality :singleValue .
+                        edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                        edo:hasTypedValue edo:floatValue ;
+                        edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#HCM
-:HCM rdf:type owl:Class ;
-     rdfs:subClassOf :ConnectionModule ;
+edo:HCM rdf:type owl:Class ;
+     rdfs:subClassOf edo:ConnectionModule ;
      dcterms:identifier "HCM" .
 
 
 ###  https://w3id.org/energy-domain/edo#HCRHose
-:HCRHose rdf:type owl:Class ;
-         rdfs:subClassOf :Tubing ;
+edo:HCRHose rdf:type owl:Class ;
+         rdfs:subClassOf edo:Tubing ;
          dcterms:identifier "HCRHose" ;
          skos:definition "High Collapse Resistant Hose"@en ;
          skos:prefLabel "HCR Hose"@en ;
-         :ifc_equivalentClass "IfcPipeSegment" ;
-         :ifc_objectType "HCRHose" ;
-         :ifc_predefinedType "USERDEFINED" .
+         edo:ifc_equivalentClass "IfcPipeSegment" ;
+         edo:ifc_objectType "HCRHose" ;
+         edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#HPHousing
-:HPHousing rdf:type owl:Class ;
-           rdfs:subClassOf :PressureComponent ;
+edo:HPHousing rdf:type owl:Class ;
+           rdfs:subClassOf edo:PressureComponent ;
            dcterms:identifier "HPHousing" .
 
 
 ###  https://w3id.org/energy-domain/edo#HVACEngineering
-:HVACEngineering rdf:type owl:Class ;
-                 rdfs:subClassOf :TechnicalDiscipline ;
+edo:HVACEngineering rdf:type owl:Class ;
+                 rdfs:subClassOf edo:TechnicalDiscipline ;
                  rdfs:label "Engenharia de HVAC"@pt-br ,
                             "HVAC Engineering"@en ;
                  skos:definition "Disciplina de engenharia focada em sistemas de aquecimento, ventilação e ar condicionado."@pt-br ,
@@ -2627,8 +2626,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#HandlingCollar
-:HandlingCollar rdf:type owl:Class ;
-                rdfs:subClassOf :SplitCollar ;
+edo:HandlingCollar rdf:type owl:Class ;
+                rdfs:subClassOf edo:SplitCollar ;
                 dcterms:identifier "HandlingCollar" ;
                 skos:altLabel "Handling Clamp"@en ,
                               "Installation Collar"@en ,
@@ -2637,14 +2636,14 @@ rdf:value rdf:type owl:DatatypeProperty .
                 skos:definition "Device used in subsea operations to facilitate the safe handling, lifting, and maneuvering of flexible pipes or heavy components during installation or retrieval. Typically attached around the pipe or component, it provides secure lifting points for cranes or other lifting equipment. Designed to distribute the load evenly, it prevents damage to the pipe or equipment while ensuring efficient and controlled movements in subsea environments."@en ;
                 skos:prefLabel "Colar de Manuseio"@pt-br ,
                                "Handling Collar"@en ;
-                :ifc_equivalentClass "IfcPipeFitting" ;
-                :ifc_objectType "HandlingCollar" ;
-                :ifc_predefinedType "USERDEFINED" .
+                edo:ifc_equivalentClass "IfcPipeFitting" ;
+                edo:ifc_objectType "HandlingCollar" ;
+                edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#HangOffCollar
-:HangOffCollar rdf:type owl:Class ;
-               rdfs:subClassOf :LineAncillary ;
+edo:HangOffCollar rdf:type owl:Class ;
+               rdfs:subClassOf edo:LineAncillary ;
                dcterms:identifier "HangOffCollar" ;
                skos:altLabel "Hang-Off Clamp"@en ,
                              "Hang-Off Device"@en ,
@@ -2653,105 +2652,105 @@ rdf:value rdf:type owl:DatatypeProperty .
                skos:definition "Device used to secure and support flexible pipes or risers during installation, particularly when they are suspended from a platform or vessel. It provides a stable attachment point, distributing the load and preventing excessive movement or strain on the pipe. The Hang Off Collar is crucial for maintaining the integrity of the pipe while it is held in place before final connection or during temporary suspension in subsea operations."@en ;
                skos:prefLabel "Hang Off Collar"@en ,
                               "Sistema de Suspensão"@pt-br ;
-               :hasAttribute :CollarInternalDiameter ,
-                             :FlangeType ,
-                             :MaxDynamicLoad ,
-                             :SafeWorkingLoad ,
-                             :UpperItubeDiameter ;
-               :ifc_equivalentClass "IfcPipeFitting" ;
-               :ifc_objectType "HangOffCollar" ;
-               :ifc_predefinedType "USERDEFINED" .
+               edo:hasAttribute edo:CollarInternalDiameter ,
+                             edo:FlangeType ,
+                             edo:MaxDynamicLoad ,
+                             edo:SafeWorkingLoad ,
+                             edo:UpperItubeDiameter ;
+               edo:ifc_equivalentClass "IfcPipeFitting" ;
+               edo:ifc_objectType "HangOffCollar" ;
+               edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#HardwareItem
-:HardwareItem rdf:type owl:Class ;
-              rdfs:subClassOf :Component ;
+edo:HardwareItem rdf:type owl:Class ;
+              rdfs:subClassOf edo:Component ;
               dcterms:identifier "HardwareItem" ;
               skos:definition "Simple mechanical items such as pipe components, etc."@en ;
               skos:prefLabel "Hardware Item"@en ,
                              "Item de Hardware"@pt-br ;
-              :hasAttribute :DisplacedVolume ,
-                            :DrawingDimensionsTable_DimensionDescription ,
-                            :DrawingDimensionsTable_DimensionName ,
-                            :DrawingDimensionsTable_DimensionUnit ,
-                            :DrawingDimensionsTable_DimensionValue ,
-                            :IdInUnifilarDiagram ,
-                            :InternalVolume ,
-                            :ManufacturerDefinedMaterialName ,
-                            :Mass ,
-                            :MaterialSupplierName ,
-                            :PartNumber ,
-                            :ProjectDrawingCode ,
-                            :ProjectDrawingRevision ,
-                            :SupplierProvidedMaterialName .
+              edo:hasAttribute edo:DisplacedVolume ,
+                            edo:DrawingDimensionsTable_DimensionDescription ,
+                            edo:DrawingDimensionsTable_DimensionName ,
+                            edo:DrawingDimensionsTable_DimensionUnit ,
+                            edo:DrawingDimensionsTable_DimensionValue ,
+                            edo:IdInUnifilarDiagram ,
+                            edo:InternalVolume ,
+                            edo:ManufacturerDefinedMaterialName ,
+                            edo:Mass ,
+                            edo:MaterialSupplierName ,
+                            edo:PartNumber ,
+                            edo:ProjectDrawingCode ,
+                            edo:ProjectDrawingRevision ,
+                            edo:SupplierProvidedMaterialName .
 
 
 ###  https://w3id.org/energy-domain/edo#HasFaceORing
-:HasFaceORing rdf:type owl:Class ;
-              rdfs:subClassOf :DomainAttribute ;
+edo:HasFaceORing rdf:type owl:Class ;
+              rdfs:subClassOf edo:DomainAttribute ;
               dcterms:accessRights "PUBLIC" ;
               dcterms:identifier "HasFaceORing" ;
               skos:definition "Indicates whether the item has a face oring (TRUE) or not (FALSE)."@en ;
               skos:prefLabel "Has Face ORing"@en ,
                              "Possui ORing na Face"@pt-br ;
-              :hasAttributeScope :TypeLevelAttribute ;
-              :hasTypedValue :booleanValue ;
-              :hasValueCardinality :singleValue .
+              edo:hasAttributeScope edo:TypeLevelAttribute ;
+              edo:hasTypedValue edo:booleanValue ;
+              edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#HasModaSensor
-:HasModaSensor rdf:type owl:Class ;
-               rdfs:subClassOf :DomainAttribute ;
+edo:HasModaSensor rdf:type owl:Class ;
+               rdfs:subClassOf edo:DomainAttribute ;
                dcterms:accessRights "PUBLIC" ;
                dcterms:identifier "HasModaSensor" ;
                skos:definition "Indicates whether the item includes a MODA sensor (TRUE) or Not (FALSE)."@en ;
                skos:prefLabel "Has Moda Sensor"@en ,
                               "Possui Sensor MODA"@pt-br ;
-               :hasAttributeScope :TypeLevelAttribute ;
-               :hasTypedValue :booleanValue ;
-               :hasValueCardinality :singleValue .
+               edo:hasAttributeScope edo:TypeLevelAttribute ;
+               edo:hasTypedValue edo:booleanValue ;
+               edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#HasN2InjectionPort
-:HasN2InjectionPort rdf:type owl:Class ;
-                    rdfs:subClassOf :DomainAttribute ;
+edo:HasN2InjectionPort rdf:type owl:Class ;
+                    rdfs:subClassOf edo:DomainAttribute ;
                     dcterms:accessRights "PUBLIC" ;
                     dcterms:identifier "HasN2InjectionPort" ;
                     skos:definition "Indicates whether the item includes a nitrogen (N2) injection port (TRUE) or Not (FALSE)."@en ;
                     skos:prefLabel "Has N2 Injection Port"@en ,
                                    "Possui Porta de Injeção de Nitrogênio"@pt-br ;
-                    :hasAttributeScope :TypeLevelAttribute ;
-                    :hasTypedValue :booleanValue ;
-                    :hasValueCardinality :singleValue .
+                    edo:hasAttributeScope edo:TypeLevelAttribute ;
+                    edo:hasTypedValue edo:booleanValue ;
+                    edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#HasThermalInsulation
-:HasThermalInsulation rdf:type owl:Class ;
-                      rdfs:subClassOf :DomainAttribute ;
+edo:HasThermalInsulation rdf:type owl:Class ;
+                      rdfs:subClassOf edo:DomainAttribute ;
                       dcterms:accessRights "PUBLIC" ;
                       dcterms:identifier "HasThermalInsulation" ;
                       skos:prefLabel "Has Thermal Insulation"@en ,
                                      "Possui isolamento térmico"@pt-br ;
-                      :hasAttributeScope :TypeLevelAttribute ;
-                      :hasTypedValue :booleanValue ;
-                      :hasValueCardinality :singleValue .
+                      edo:hasAttributeScope edo:TypeLevelAttribute ;
+                      edo:hasTypedValue edo:booleanValue ;
+                      edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#HighStrengthTape
-:HighStrengthTape rdf:type owl:Class ;
-                  rdfs:subClassOf :TapeLayer ;
+edo:HighStrengthTape rdf:type owl:Class ;
+                  rdfs:subClassOf edo:TapeLayer ;
                   dcterms:identifier "HighStrengthTape" ;
                   skos:definition "Material used in subsea flexible pipes, typically applied as a reinforcing layer to provide additional strength and resistance to external forces. High Strength Tape is designed to improve the tensile properties of the flexible pipe, enhancing its ability to withstand high internal pressures, tension, and dynamic loads in harsh subsea environments. It is typically made from advanced fibers or composite materials, ensuring durability and long-term performance in demanding conditions."@en ;
                   skos:prefLabel "Fita de Alta Resistência"@pt-br ,
                                  "High Strength Tape"@en ;
-                  :ifc_equivalentClass "IfcPipeSegment" ;
-                  :ifc_objectType "HighStrengthTape" ;
-                  :ifc_predefinedType "USERDEFINED" .
+                  edo:ifc_equivalentClass "IfcPipeSegment" ;
+                  edo:ifc_objectType "HighStrengthTape" ;
+                  edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#HistoricalAttribute
-:HistoricalAttribute rdf:type owl:Class ;
-                     rdfs:subClassOf :AttributeDomainCategory ;
+edo:HistoricalAttribute rdf:type owl:Class ;
+                     rdfs:subClassOf edo:AttributeDomainCategory ;
                      rdfs:comment "Represents records of past events, inspections, or modifications."@en ;
                      rdfs:label "Atributo Histórico"@pt-br ,
                                 "Historical Attribute"@en ;
@@ -2760,59 +2759,59 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#HoldingBandage
-:HoldingBandage rdf:type owl:Class ;
-                rdfs:subClassOf :TapeLayer ;
+edo:HoldingBandage rdf:type owl:Class ;
+                rdfs:subClassOf edo:TapeLayer ;
                 dcterms:identifier "HoldingBandage" ;
                 skos:definition "Reinforcement layer used in subsea flexible pipes to secure and hold internal components in place during manufacturing and operation. The Holding Bandage helps maintain the alignment and stability of the various layers of the pipe, preventing displacement or movement under dynamic conditions. Typically made from high-strength, flexible materials, it contributes to the overall durability and structural integrity of the pipe, ensuring reliable performance in harsh subsea environments."@en ;
                 skos:prefLabel "Bandagem de Reforço"@pt-br ,
                                "Holding Bandage"@en ;
-                :hasAttribute :ModulusOfElasticity ,
-                              :StressAtDesignPressure ,
-                              :TapesQuantity ;
-                :ifc_equivalentClass "IfcPipeSegment" ;
-                :ifc_objectType "HoldingBandage" ;
-                :ifc_predefinedType "USERDEFINED" .
+                edo:hasAttribute edo:ModulusOfElasticity ,
+                              edo:StressAtDesignPressure ,
+                              edo:TapesQuantity ;
+                edo:ifc_equivalentClass "IfcPipeSegment" ;
+                edo:ifc_objectType "HoldingBandage" ;
+                edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#Hook
-:Hook rdf:type owl:Class ;
-      rdfs:subClassOf :MooringAccessory ;
+edo:Hook rdf:type owl:Class ;
+      rdfs:subClassOf edo:MooringAccessory ;
       dcterms:identifier "Hook" .
 
 
 ###  https://w3id.org/energy-domain/edo#Hub
-:Hub rdf:type owl:Class ;
-     rdfs:subClassOf :PressureComponent ;
+edo:Hub rdf:type owl:Class ;
+     rdfs:subClassOf edo:PressureComponent ;
      dcterms:identifier "Hub" .
 
 
 ###  https://w3id.org/energy-domain/edo#HubBlockCap
-:HubBlockCap rdf:type owl:Class ;
-             rdfs:subClassOf :FlowControlModule ;
+edo:HubBlockCap rdf:type owl:Class ;
+             rdfs:subClassOf edo:FlowControlModule ;
              dcterms:identifier "HubBlockCap" .
 
 
 ###  https://w3id.org/energy-domain/edo#HubProtectionCap
-:HubProtectionCap rdf:type owl:Class ;
-                  rdfs:subClassOf :Accessory ;
+edo:HubProtectionCap rdf:type owl:Class ;
+                  rdfs:subClassOf edo:Accessory ;
                   dcterms:identifier "HubProtectionCap" .
 
 
 ###  https://w3id.org/energy-domain/edo#HydraulicJumper
-:HydraulicJumper rdf:type owl:Class ;
-                 rdfs:subClassOf :Jumper ;
+edo:HydraulicJumper rdf:type owl:Class ;
+                 rdfs:subClassOf edo:Jumper ;
                  dcterms:identifier "HydraulicJumper" .
 
 
 ###  https://w3id.org/energy-domain/edo#HydraulicPowerUnit
-:HydraulicPowerUnit rdf:type owl:Class ;
-                    rdfs:subClassOf :TopsideEquipment ;
+edo:HydraulicPowerUnit rdf:type owl:Class ;
+                    rdfs:subClassOf edo:TopsideEquipment ;
                     dcterms:identifier "HydraulicPowerUnit" .
 
 
 ###  https://w3id.org/energy-domain/edo#HydrogenEnergy
-:HydrogenEnergy rdf:type owl:Class ;
-                rdfs:subClassOf :Domain ;
+edo:HydrogenEnergy rdf:type owl:Class ;
+                rdfs:subClassOf edo:Domain ;
                 rdfs:label "Energia de Hidrogênio"@pt-br ,
                            "Hydrogen Energy"@en ;
                 skos:definition "Production, storage, and utilization of hydrogen as an energy carrier."@en ,
@@ -2820,8 +2819,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#Hydropower
-:Hydropower rdf:type owl:Class ;
-            rdfs:subClassOf :Renewable ;
+edo:Hydropower rdf:type owl:Class ;
+            rdfs:subClassOf edo:Renewable ;
             rdfs:label "Energia Hidrelétrica"@pt-br ,
                        "Hydropower"@en ;
             skos:definition "Energia gerada a partir da água em movimento, incluindo barragens e energia das marés."@pt-br ,
@@ -2829,54 +2828,54 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#HydrostaticCollapseAbsPressDry
-:HydrostaticCollapseAbsPressDry rdf:type owl:Class ;
-                                rdfs:subClassOf :DomainAttribute ;
+edo:HydrostaticCollapseAbsPressDry rdf:type owl:Class ;
+                                rdfs:subClassOf edo:DomainAttribute ;
                                 dcterms:accessRights "PUBLIC" ;
                                 dcterms:identifier "HydrostaticCollapseAbsPressDry" ;
                                 skos:definition "Pressão Absoluta de colapso hidrostático, anular seco, linha reta"@pt-br ,
                                                 "Represents the absolute pressure at which a component or material will collapse under hydrostatic forces when in a dry state. This property is important for evaluating the material's ability to withstand external pressure without deformation or failure."@en ;
                                 skos:prefLabel "Hydrostatic Collapse Absolute Pressure Dry"@en ,
                                                "Pressão Absoluta de Colapso Hidrostático a Seco"@pt-br ;
-                                :hasAttributeScope :TypeLevelAttribute ;
-                                :hasTypedValue :floatValue ;
-                                :hasValueCardinality :singleValue .
+                                edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                edo:hasTypedValue edo:floatValue ;
+                                edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#HydrostaticPressureTestsAttribute
-:HydrostaticPressureTestsAttribute rdf:type owl:Class ;
-                                   rdfs:subClassOf :DomainAttribute .
+edo:HydrostaticPressureTestsAttribute rdf:type owl:Class ;
+                                   rdfs:subClassOf edo:DomainAttribute .
 
 
 ###  https://w3id.org/energy-domain/edo#IMUX
-:IMUX rdf:type owl:Class ;
-      rdfs:subClassOf :ElectronicDevice ;
+edo:IMUX rdf:type owl:Class ;
+      rdfs:subClassOf edo:ElectronicDevice ;
       dcterms:identifier "IMUX" .
 
 
 ###  https://w3id.org/energy-domain/edo#ITube
-:ITube rdf:type owl:Class ;
-       rdfs:subClassOf :RiserSupport ;
+edo:ITube rdf:type owl:Class ;
+       rdfs:subClassOf edo:RiserSupport ;
        dcterms:identifier "ITube" .
 
 
 ###  https://w3id.org/energy-domain/edo#IdInUnifilarDiagram
-:IdInUnifilarDiagram rdf:type owl:Class ;
-                     rdfs:subClassOf :DomainAttribute ;
+edo:IdInUnifilarDiagram rdf:type owl:Class ;
+                     rdfs:subClassOf edo:DomainAttribute ;
                      dcterms:accessRights "PUBLIC" ;
                      dcterms:identifier "IdInUnifilarDiagram" ;
                      skos:definition "Identificador do item no diagrama unifilar (unifilar \"classico\", pre-existente) conforme a coluna \"item\" do unifilar."@pt-br ,
                                      "Numeric identifier used to represent the component in a unifilar diagram, ensuring clear reference and traceability within the diagram. This identifier allows for easy identification of the component's position and connection points in the simplified representation of the system."@en ;
                      skos:prefLabel "Id In Unifilar Diagram"@en ,
                                     "Identificador no Diagrama Unifilar"@pt-br ;
-                     :hasAttributeScope :InstanceLevelAttribute ,
-                                        :TypeLevelAttribute ;
-                     :hasTypedValue :intValue ;
-                     :hasValueCardinality :singleValue .
+                     edo:hasAttributeScope edo:InstanceLevelAttribute ,
+                                        edo:TypeLevelAttribute ;
+                     edo:hasTypedValue edo:intValue ;
+                     edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#IdentificationAttribute
-:IdentificationAttribute rdf:type owl:Class ;
-                         rdfs:subClassOf :AttributeDomainCategory ;
+edo:IdentificationAttribute rdf:type owl:Class ;
+                         rdfs:subClassOf edo:AttributeDomainCategory ;
                          rdfs:comment "Represents identifiers, codes, names."@en ;
                          rdfs:label "Atributo de Identificação"@pt-br ,
                                     "Identification Attribute"@en ;
@@ -2885,8 +2884,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#ImportedValue
-:ImportedValue rdf:type owl:Class ;
-               rdfs:subClassOf :ValueOrigin ;
+edo:ImportedValue rdf:type owl:Class ;
+               rdfs:subClassOf edo:ValueOrigin ;
                rdfs:comment "Imported from another system."@en ;
                rdfs:label "Importado"@pt-br ,
                           "Imported"@en ;
@@ -2895,64 +2894,64 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#IndividualAnodeMass
-:IndividualAnodeMass rdf:type owl:Class ;
-                     rdfs:subClassOf :DomainAttribute ;
+edo:IndividualAnodeMass rdf:type owl:Class ;
+                     rdfs:subClassOf edo:DomainAttribute ;
                      dcterms:accessRights "PUBLIC" ;
                      dcterms:identifier "IndividualAnodeMass" ;
                      skos:definition "Total mass of the sacrificial anode material within each individual anode."@en ;
                      skos:prefLabel "Individual Anode Mass"@en ,
                                     "Massa Individual do Anodo"@pt-br ;
-                     :hasAttributeScope :TypeLevelAttribute ;
-                     :hasTypedValue :floatValue ;
-                     :hasValueCardinality :singleValue .
+                     edo:hasAttributeScope edo:TypeLevelAttribute ;
+                     edo:hasTypedValue edo:floatValue ;
+                     edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#InlineT
-:InlineT rdf:type owl:Class ;
-         rdfs:subClassOf :FlowControlEquipment ;
+edo:InlineT rdf:type owl:Class ;
+         rdfs:subClassOf edo:FlowControlEquipment ;
          dcterms:identifier "InlineT" .
 
 
 ###  https://w3id.org/energy-domain/edo#InlineValve
-:InlineValve rdf:type owl:Class ;
-             rdfs:subClassOf :FlowControlEquipment ;
+edo:InlineValve rdf:type owl:Class ;
+             rdfs:subClassOf edo:FlowControlEquipment ;
              dcterms:identifier "InlineValve" .
 
 
 ###  https://w3id.org/energy-domain/edo#InlineY
-:InlineY rdf:type owl:Class ;
-         rdfs:subClassOf :FlowControlEquipment ;
+edo:InlineY rdf:type owl:Class ;
+         rdfs:subClassOf edo:FlowControlEquipment ;
          dcterms:identifier "InlineY" .
 
 
 ###  https://w3id.org/energy-domain/edo#InnerTube
-:InnerTube rdf:type owl:Class ;
-           rdfs:subClassOf :SolidLayer ;
+edo:InnerTube rdf:type owl:Class ;
+           rdfs:subClassOf edo:SolidLayer ;
            dcterms:identifier "InnerTube" ;
            skos:definition "The Inner Tube is the innermost layer of a subsea flexible pipe, responsible for containing and transporting the fluid, such as oil or gas. It is designed to withstand internal pressures and prevent fluid leakage while offering resistance to the corrosive and abrasive nature of the transported substances. The Inner Tube is typically made from high-performance polymeric materials that ensure durability, flexibility, and chemical resistance, making it a critical component in maintaining the integrity of the flexible pipe in subsea operations."@en ;
            skos:prefLabel "Inner Tube"@en ,
                           "Tubo Interno"@pt-br ;
-           :ifc_equivalentClass "IfcPipeSegment" ;
-           :ifc_objectType "InnerTube" ;
-           :ifc_predefinedType "USERDEFINED" .
+           edo:ifc_equivalentClass "IfcPipeSegment" ;
+           edo:ifc_objectType "InnerTube" ;
+           edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#InsideTemperature
-:InsideTemperature rdf:type owl:Class ;
-                   rdfs:subClassOf :BendingStiffnessAttribute ;
+edo:InsideTemperature rdf:type owl:Class ;
+                   rdfs:subClassOf edo:BendingStiffnessAttribute ;
                    dcterms:accessRights "PUBLIC" ;
                    dcterms:identifier "InsideTemperature" ;
                    skos:definition "Represents the internal temperature within a component or system. This property is important for assessing the thermal conditions inside the system, ensuring that it operates within safe temperature limits, particularly in subsea environments where temperature control is essential for maintaining performance and integrity."@en ;
                    skos:prefLabel "Inside Temperature"@en ,
                                   "Temperatura Interna"@pt-br ;
-                   :hasAttributeScope :TypeLevelAttribute ;
-                   :hasTypedValue :floatValue ;
-                   :hasValueCardinality :singleValue .
+                   edo:hasAttributeScope edo:TypeLevelAttribute ;
+                   edo:hasTypedValue edo:floatValue ;
+                   edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#Installation
-:Installation rdf:type owl:Class ;
-              rdfs:subClassOf :LifecyclePhase ;
+edo:Installation rdf:type owl:Class ;
+              rdfs:subClassOf edo:LifecyclePhase ;
               rdfs:label "Instalação"@pt-br ,
                          "Installation"@en ;
               skos:definition "Placement and integration of equipment, piping, and structures at the site."@en ,
@@ -2960,8 +2959,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#InstanceLevelAttribute
-:InstanceLevelAttribute rdf:type owl:Class ;
-                        rdfs:subClassOf :AttributeScope ;
+edo:InstanceLevelAttribute rdf:type owl:Class ;
+                        rdfs:subClassOf edo:AttributeScope ;
                         rdfs:comment "Attribute specific to a real-world individual instance of item."@en ;
                         rdfs:label "Atributo de Instância"@pt-br ,
                                    "Instance-Level Attribute"@en ;
@@ -2970,8 +2969,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#InstrumentationEngineering
-:InstrumentationEngineering rdf:type owl:Class ;
-                            rdfs:subClassOf :TechnicalDiscipline ;
+edo:InstrumentationEngineering rdf:type owl:Class ;
+                            rdfs:subClassOf edo:TechnicalDiscipline ;
                             rdfs:label "Engenharia de Instrumentação"@pt-br ,
                                        "Instrumentation Engineering"@en ;
                             skos:definition "Disciplina de engenharia focada em sistemas de instrumentação de medição e controle."@pt-br ,
@@ -2979,29 +2978,29 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#InsulationTape
-:InsulationTape rdf:type owl:Class ;
-                rdfs:subClassOf :TapeLayer ;
+edo:InsulationTape rdf:type owl:Class ;
+                rdfs:subClassOf edo:TapeLayer ;
                 dcterms:identifier "InsulationTape" ;
                 skos:definition "Material used in subsea flexible pipes to provide thermal insulation, ensuring that the temperature of the transported fluids remains stable during flow. Insulation Tape is applied in layers around the pipe to minimize heat loss or gain, which is critical for maintaining the fluid's properties, such as viscosity, in deepwater environments. It is typically made from materials with low thermal conductivity, such as polymers or composites, and is essential for enhancing the efficiency and performance of subsea pipelines in harsh temperature conditions."@en ;
                 skos:prefLabel "Fita de Isolamento"@pt-br ,
                                "Insulation Tape"@en ;
-                :ifc_equivalentClass "IfcPipeSegment" ;
-                :ifc_objectType "InsulationTape" ;
-                :ifc_predefinedType "USERDEFINED" .
+                edo:ifc_equivalentClass "IfcPipeSegment" ;
+                edo:ifc_objectType "InsulationTape" ;
+                edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#IntegratedPipe
-:IntegratedPipe rdf:type owl:Class ;
-                rdfs:subClassOf :Tubing ;
+edo:IntegratedPipe rdf:type owl:Class ;
+                rdfs:subClassOf edo:Tubing ;
                 dcterms:identifier "IntegratedPipe" ;
-                :ifc_equivalentClass "IfcPipeSegment" ;
-                :ifc_objectType "IntegratedPipe" ;
-                :ifc_predefinedType "USERDEFINED" .
+                edo:ifc_equivalentClass "IfcPipeSegment" ;
+                edo:ifc_objectType "IntegratedPipe" ;
+                edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#Interconnection
-:Interconnection rdf:type owl:Class ;
-                 rdfs:subClassOf :LinearLocation ;
+edo:Interconnection rdf:type owl:Class ;
+                 rdfs:subClassOf edo:LinearLocation ;
                  dcterms:identifier "Interconnection" ;
                  skos:definition "Location that contains the entire length of an interconnection, with its various sections, terminations, inline equipment, etc."@en ;
                  skos:prefLabel "Interconnection"@en ,
@@ -3009,20 +3008,20 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#InterlockedCarcass
-:InterlockedCarcass rdf:type owl:Class ;
-                    rdfs:subClassOf :CarcassLayer ;
+edo:InterlockedCarcass rdf:type owl:Class ;
+                    rdfs:subClassOf edo:CarcassLayer ;
                     dcterms:identifier "InterlockedCarcass" ;
                     skos:definition "The Interlocked Carcass is a metallic layer used in certain subsea flexible pipes to provide internal pressure resistance and prevent collapse. It is designed with interlocking metal strips that offer high strength while maintaining flexibility. This layer enhances the structural integrity of the flexible pipe, protecting it from external pressures and harsh subsea conditions. The Interlocked Carcass allows the pipe to bend without losing its shape or collapsing under deepwater pressure."@en ;
                     skos:prefLabel "Carcaça"@pt-br ,
                                    "Interlocked Carcass"@en ;
-                    :ifc_equivalentClass "IfcPipeSegment" ;
-                    :ifc_objectType "InterlockedCarcass" ;
-                    :ifc_predefinedType "USERDEFINED" .
+                    edo:ifc_equivalentClass "IfcPipeSegment" ;
+                    edo:ifc_objectType "InterlockedCarcass" ;
+                    edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#IntermediateBendStiffener
-:IntermediateBendStiffener rdf:type owl:Class ;
-                           rdfs:subClassOf :BendStiffener ;
+edo:IntermediateBendStiffener rdf:type owl:Class ;
+                           rdfs:subClassOf edo:BendStiffener ;
                            dcterms:identifier "IntermediateBendStiffener" ;
                            skos:altLabel "Curvature Stiffener"@en ,
                                          "Intermediate Bending Stiffener"@en ,
@@ -3031,443 +3030,443 @@ rdf:value rdf:type owl:DatatypeProperty .
                                            "Dispositivo usado em tubos flexíveis submarinos para fornecer rigidez localizada em pontos específicos ao longo do comprimento do tubo, evitando dobras excessivas e reduzindo a concentração de tensões. O Enrijecedor de Curvatura Intermediário é tipicamente instalado entre áreas críticas para garantir que o tubo mantenha um raio de curvatura controlado, protegendo-o contra flexões excessivas ou fadiga. Feito de materiais duráveis, ajuda a prolongar a vida útil do tubo flexível, distribuindo as cargas de forma mais uniforme e reduzindo o risco de danos em ambientes submarinos dinâmicos."@pt-br ;
                            skos:prefLabel "Enrijecedor de Curvatura Intermediário"@pt-br ,
                                           "Intermediate Bend Stiffener"@en ;
-                           :ifc_equivalentClass "IfcPipeFitting" ;
-                           :ifc_objectType "IntermediateBendStiffener" .
+                           edo:ifc_equivalentClass "IfcPipeFitting" ;
+                           edo:ifc_objectType "IntermediateBendStiffener" .
 
 
 ###  https://w3id.org/energy-domain/edo#IntermediateSheath
-:IntermediateSheath rdf:type owl:Class ;
-                    rdfs:subClassOf :SolidLayer ;
+edo:IntermediateSheath rdf:type owl:Class ;
+                    rdfs:subClassOf edo:SolidLayer ;
                     dcterms:identifier "IntermediateSheath" ;
                     skos:definition "A protective layer within a subsea flexible pipe, positioned between other structural layers to provide additional protection and separation. The Intermediate Sheath serves to isolate different layers, preventing abrasion, wear, or interaction that could compromise the integrity of the pipe. Typically made from polymeric materials, this sheath also contributes to the overall durability and flexibility of the pipe, ensuring it can withstand the dynamic conditions of subsea environments while maintaining the performance of the internal and external layers."@en ;
                     skos:prefLabel "Barreira Intermediária de Vedação"@pt-br ,
                                    "Intermediate Sheath"@en ;
-                    :ifc_equivalentClass "IfcPipeSegment" ;
-                    :ifc_objectType "IntermediateSheath" ;
-                    :ifc_predefinedType "USERDEFINED" .
+                    edo:ifc_equivalentClass "IfcPipeSegment" ;
+                    edo:ifc_objectType "IntermediateSheath" ;
+                    edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#IntermediateValuesStrategy
-:IntermediateValuesStrategy rdf:type owl:Class ;
-                            rdfs:subClassOf :BendingStiffnessAttribute ,
-                                            :CrushingFrictionCoefficientTighteningAttribute ,
-                                            :CrushingMaximumAllowableTensionAttribute ,
-                                            :CrushingMaximumAllowableTighteningAttribute ;
+edo:IntermediateValuesStrategy rdf:type owl:Class ;
+                            rdfs:subClassOf edo:BendingStiffnessAttribute ,
+                                            edo:CrushingFrictionCoefficientTighteningAttribute ,
+                                            edo:CrushingMaximumAllowableTensionAttribute ,
+                                            edo:CrushingMaximumAllowableTighteningAttribute ;
                             dcterms:accessRights "PUBLIC" ;
                             dcterms:identifier "IntermediateValuesStrategy" ;
                             skos:definition "Defines the approach used to handle or calculate intermediate values between specified data points. This property is important for ensuring accuracy in analysis or simulations, particularly when determining values that fall between measured or specified conditions."@en ;
                             skos:prefLabel "Estratégia para Valores Intermediários"@pt-br ,
                                            "Intermediate Values Strategy"@en ;
-                            :hasAttributeScope :TypeLevelAttribute ;
-                            :hasTypedValue :stringValue ;
-                            :hasValueCardinality :singleValue .
+                            edo:hasAttributeScope edo:TypeLevelAttribute ;
+                            edo:hasTypedValue edo:stringValue ;
+                            edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#InternalDiameter
-:InternalDiameter rdf:type owl:Class ;
-                  rdfs:subClassOf :DomainAttribute ;
+edo:InternalDiameter rdf:type owl:Class ;
+                  rdfs:subClassOf edo:DomainAttribute ;
                   dcterms:accessRights "PUBLIC" ;
                   dcterms:identifier "InternalDiameter" ;
                   skos:definition "Distance measured across the innermost points, passing through the center."@en ;
                   skos:prefLabel "Diâmetro interno"@pt-br ,
                                  "Internal Diameter"@en ;
-                  :hasAttributeScope :InstanceLevelAttribute ,
-                                     :TypeLevelAttribute ;
-                  :hasTypedValue :floatValue ;
-                  :hasValueCardinality :singleValue .
+                  edo:hasAttributeScope edo:InstanceLevelAttribute ,
+                                     edo:TypeLevelAttribute ;
+                  edo:hasTypedValue edo:floatValue ;
+                  edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#InternalIncidentalPressureTable
-:InternalIncidentalPressureTable rdf:type owl:Class ;
-                                 rdfs:subClassOf :DomainAttribute ;
+edo:InternalIncidentalPressureTable rdf:type owl:Class ;
+                                 rdfs:subClassOf edo:DomainAttribute ;
                                  dcterms:accessRights "PUBLIC" ;
                                  dcterms:identifier "InternalIncidentalPressureTable" ;
                                  skos:definition "Provides data on internal incidental pressures, which are temporary or unexpected pressure spikes within the structure. This information is crucial for understanding the pressure limits the structure may face and ensuring it can withstand short-term variations without compromising its integrity."@en ;
                                  skos:prefLabel "Internal Incidental Pressure Table"@en ,
                                                 "Tabela de Pressão Incidental Interna"@pt-br ;
-                                 :hasAttributeScope :InstanceLevelAttribute .
+                                 edo:hasAttributeScope edo:InstanceLevelAttribute .
 
 
 ###  https://w3id.org/energy-domain/edo#InternalIncidentalPressureTable_PositionReference
-:InternalIncidentalPressureTable_PositionReference rdf:type owl:Class ;
-                                                   rdfs:subClassOf :InternalIncidentalPressureTable ;
+edo:InternalIncidentalPressureTable_PositionReference rdf:type owl:Class ;
+                                                   rdfs:subClassOf edo:InternalIncidentalPressureTable ;
                                                    dcterms:accessRights "PUBLIC" ;
                                                    dcterms:identifier "InternalIncidentalPressureTable_PositionReference" ;
                                                    skos:definition "Identifies the specific point along the pipeline. This serves as the reference for vertical position and pressure values."@en ,
                                                                    "Valores válidos:Top (Para a conexão topside - E.g. Conector superior)TDPSubSeaConnection (Ex. ANM)"@pt-br ;
                                                    skos:prefLabel "Position Reference"@en ,
                                                                   "Referência de Posição"@pt-br ;
-                                                   :hasAttributeScope :InstanceLevelAttribute ;
-                                                   :hasTypedValue :stringValue ;
-                                                   :hasValueCardinality :multiValue .
+                                                   edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                                   edo:hasTypedValue edo:stringValue ;
+                                                   edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#InternalIncidentalPressureTable_Pressure
-:InternalIncidentalPressureTable_Pressure rdf:type owl:Class ;
-                                          rdfs:subClassOf :InternalIncidentalPressureTable ;
+edo:InternalIncidentalPressureTable_Pressure rdf:type owl:Class ;
+                                          rdfs:subClassOf edo:InternalIncidentalPressureTable ;
                                           dcterms:accessRights "PUBLIC" ;
                                           dcterms:identifier "InternalIncidentalPressureTable_Pressure" ;
                                           skos:definition "Indicates the force exerted per unit area on the surface of a material or component. This property is critical for evaluating how the component responds to external or internal forces, ensuring it can withstand operational pressure conditions."@en ;
                                           skos:prefLabel "Pressure"@en ,
                                                          "Pressão"@pt-br ;
-                                          :hasAttributeScope :InstanceLevelAttribute ;
-                                          :hasTypedValue :floatValue ;
-                                          :hasValueCardinality :multiValue .
+                                          edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                          edo:hasTypedValue edo:floatValue ;
+                                          edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#InternalIncidentalPressureTable_VPosWRTWaterline
-:InternalIncidentalPressureTable_VPosWRTWaterline rdf:type owl:Class ;
-                                                  rdfs:subClassOf :InternalIncidentalPressureTable ;
+edo:InternalIncidentalPressureTable_VPosWRTWaterline rdf:type owl:Class ;
+                                                  rdfs:subClassOf edo:InternalIncidentalPressureTable ;
                                                   dcterms:accessRights "PUBLIC" ;
                                                   dcterms:identifier "InternalIncidentalPressureTable_VPosWRTWaterline" ;
                                                   skos:definition "Valores negativos para pontos submersos, e valores positivos para pontos acima da água. Considerando calado máximo da plataforma, quando aplicável."@pt-br ,
                                                                   "Vertical position with respect to the waterline, where positive values indicate points above the water and negative values indicate points below. The platform's maximum draft is considered when applicable."@en ;
                                                   skos:prefLabel "Posição Vertical em Relação à Linha D'Água"@pt-br ,
                                                                  "Vertical Position With Respect To Waterline"@en ;
-                                                  :hasAttributeScope :InstanceLevelAttribute ;
-                                                  :hasTypedValue :intValue ;
-                                                  :hasValueCardinality :multiValue .
+                                                  edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                                  edo:hasTypedValue edo:intValue ;
+                                                  edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#InternalPressureSheath
-:InternalPressureSheath rdf:type owl:Class ;
-                        rdfs:subClassOf :SolidLayer ;
+edo:InternalPressureSheath rdf:type owl:Class ;
+                        rdfs:subClassOf edo:SolidLayer ;
                         dcterms:identifier "InternalPressureSheath" ;
                         skos:definition "A layer within a subsea flexible pipe designed to contain the internal fluid and withstand the internal pressure exerted by the transported medium, such as oil, gas, or water. The Internal Pressure Sheath plays a crucial role in preventing fluid leakage and maintaining pressure integrity within the pipe. Typically made from high-performance polymeric materials, it ensures the safe transport of fluids under high-pressure conditions, contributing to the pipe's overall structural stability and long-term reliability in harsh subsea environments."@en ;
                         skos:prefLabel "Barreira Interna de Pressão"@pt-br ,
                                        "Internal Pressure Sheath"@en ;
-                        :ifc_equivalentClass "IfcPipeSegment" ;
-                        :ifc_objectType "InternalPressureSheath" ;
-                        :ifc_predefinedType "USERDEFINED" .
+                        edo:ifc_equivalentClass "IfcPipeSegment" ;
+                        edo:ifc_objectType "InternalPressureSheath" ;
+                        edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#InternalVolume
-:InternalVolume rdf:type owl:Class ;
-                rdfs:subClassOf :DomainAttribute ;
+edo:InternalVolume rdf:type owl:Class ;
+                rdfs:subClassOf edo:DomainAttribute ;
                 dcterms:accessRights "PUBLIC" ;
                 dcterms:identifier "InternalVolume" ;
                 skos:definition "Refers to the volume of space within an object that can be occupied by a fluid when the object is fully filled or immersed. This property is essential for understanding the capacity and fluid-holding capabilities of the accessory."@en ;
                 skos:prefLabel "Internal Volume"@en ,
                                "Volume interno"@pt-br ;
-                :hasAttributeScope :TypeLevelAttribute ;
-                :hasTypedValue :floatValue ;
-                :hasValueCardinality :singleValue .
+                edo:hasAttributeScope edo:TypeLevelAttribute ;
+                edo:hasTypedValue edo:floatValue ;
+                edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#IsSpare
-:IsSpare rdf:type owl:Class ;
-         rdfs:subClassOf :DomainAttribute ;
+edo:IsSpare rdf:type owl:Class ;
+         rdfs:subClassOf edo:DomainAttribute ;
          dcterms:accessRights "PUBLIC" ;
          dcterms:identifier "IsSpare" ;
          skos:definition "Indicates whether the item is spare (TRUE) or not (FALSE)."@en ;
          skos:prefLabel "Is Spare"@en ,
                         "É um sobressalente"@pt-br ;
-         :hasAttributeScope :InstanceLevelAttribute ;
-         :hasTypedValue :booleanValue ;
-         :hasValueCardinality :singleValue .
+         edo:hasAttributeScope edo:InstanceLevelAttribute ;
+         edo:hasTypedValue edo:booleanValue ;
+         edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#Jumper
-:Jumper rdf:type owl:Class ;
-        rdfs:subClassOf :LinearObject ;
+edo:Jumper rdf:type owl:Class ;
+        rdfs:subClassOf edo:LinearObject ;
         dcterms:identifier "Jumper" .
 
 
 ###  https://w3id.org/energy-domain/edo#JustificationAttribute
-:JustificationAttribute rdf:type owl:Class ;
-                        rdfs:subClassOf :DomainAttribute .
+edo:JustificationAttribute rdf:type owl:Class ;
+                        rdfs:subClassOf edo:DomainAttribute .
 
 
 ###  https://w3id.org/energy-domain/edo#LPHousing
-:LPHousing rdf:type owl:Class ;
-           rdfs:subClassOf :PressureComponent ;
+edo:LPHousing rdf:type owl:Class ;
+           rdfs:subClassOf edo:PressureComponent ;
            dcterms:identifier "LPHousing" .
 
 
 ###  https://w3id.org/energy-domain/edo#LayerAnnular
-:LayerAnnular rdf:type owl:Class ;
-              rdfs:subClassOf :DomainAttribute ;
+edo:LayerAnnular rdf:type owl:Class ;
+              rdfs:subClassOf edo:DomainAttribute ;
               dcterms:accessRights "PUBLIC" ;
               dcterms:identifier "LayerAnnular" ;
               skos:definition "Indicates whether the layer is part of the annular structure of the tensile armours. If true, it confirms that the layer contributes to the annular arrangement, which is important for understanding its role in the structural integrity and load distribution."@en ,
                               "True se a camada faz parte do anular das armaduras de tração"@pt-br ;
               skos:prefLabel "Camada Anular"@pt-br ,
                              "Layer Annular"@en ;
-              :hasAttributeScope :InstanceLevelAttribute ;
-              :hasTypedValue :booleanValue ;
-              :hasValueCardinality :singleValue .
+              edo:hasAttributeScope edo:InstanceLevelAttribute ;
+              edo:hasTypedValue edo:booleanValue ;
+              edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LayerAnnularType
-:LayerAnnularType rdf:type owl:Class ;
-                  rdfs:subClassOf :DomainAttribute ;
+edo:LayerAnnularType rdf:type owl:Class ;
+                  rdfs:subClassOf edo:DomainAttribute ;
                   dcterms:accessRights "PUBLIC" ;
                   dcterms:identifier "LayerAnnularType" ;
                   skos:definition "Specifies the type of annular layer based on the condition it is designed for. This information is crucial for understanding the intended role of the layer in the overall structural configuration and how it is expected to perform under the projected operational conditions."@en ,
                                   "Tipo de anular conforme o estado do anular: Não pertence ao anular; Anular nunca alagado; Anular sempre alagado; Anular possivelmente alagado"@pt-br ;
                   skos:prefLabel "Layer Annular Type"@en ,
                                  "Tipo de Anular"@pt-br ;
-                  :hasAttributeScope :InstanceLevelAttribute ;
-                  :hasTypedValue :stringValue ;
-                  :hasValueCardinality :singleValue .
+                  edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                  edo:hasTypedValue edo:stringValue ;
+                  edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LayerContinuity
-:LayerContinuity rdf:type owl:Class ;
-                 rdfs:subClassOf :DomainAttribute ;
+edo:LayerContinuity rdf:type owl:Class ;
+                 rdfs:subClassOf edo:DomainAttribute ;
                  dcterms:accessRights "PUBLIC" ;
                  dcterms:identifier "LayerContinuity" ;
                  skos:definition "Indicates whether the layer is continuous, such as when it is extruded. If true, it confirms that the layer has no interruptions or joints, which is important for ensuring uniformity and strength in the structure."@en ,
                                  "True se a camada é contínua (extrudada)"@pt-br ;
                  skos:prefLabel "Continuidade da Camada"@pt-br ,
                                 "Layer Continuity"@en ;
-                 :hasAttributeScope :InstanceLevelAttribute ;
-                 :hasTypedValue :booleanValue ;
-                 :hasValueCardinality :singleValue .
+                 edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                 edo:hasTypedValue edo:booleanValue ;
+                 edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LayerGeometryAttribute
-:LayerGeometryAttribute rdf:type owl:Class ;
-                        rdfs:subClassOf :DomainAttribute .
+edo:LayerGeometryAttribute rdf:type owl:Class ;
+                        rdfs:subClassOf edo:DomainAttribute .
 
 
 ###  https://w3id.org/energy-domain/edo#LayerGeometryCrossSection
-:LayerGeometryCrossSection rdf:type owl:Class ;
-                           rdfs:subClassOf :LayerGeometryAttribute ;
+edo:LayerGeometryCrossSection rdf:type owl:Class ;
+                           rdfs:subClassOf edo:LayerGeometryAttribute ;
                            dcterms:accessRights "PUBLIC" ;
                            dcterms:identifier "LayerGeometryCrossSection" ;
                            skos:definition "Indicates the geometry of the layer's cross-section. This property provides detailed information about the shape and dimensions of the layer when viewed in cross-section, which is important for understanding how the layer contributes to the overall structure's performance and integrity."@en ;
                            skos:prefLabel "Layer Geometry Cross Section"@en ,
                                           "Seção Transversal da Geometria da Camada"@pt-br ;
-                           :hasAttributeScope :InstanceLevelAttribute ;
-                           :hasTypedValue :floatValue ;
-                           :hasValueCardinality :singleValue .
+                           edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                           edo:hasTypedValue edo:floatValue ;
+                           edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LayerGeometryInertiaX
-:LayerGeometryInertiaX rdf:type owl:Class ;
-                       rdfs:subClassOf :LayerGeometryAttribute ;
+edo:LayerGeometryInertiaX rdf:type owl:Class ;
+                       rdfs:subClassOf edo:LayerGeometryAttribute ;
                        dcterms:accessRights "PUBLIC" ;
                        dcterms:identifier "LayerGeometryInertiaX" ;
                        skos:definition "Indicates the moment of inertia of the layer's geometry around the X-axis. This property is crucial for understanding the layer's resistance to bending or deformation when subjected to forces along the X-axis, contributing to the structural stability and performance of the component."@en ;
                        skos:prefLabel "Inércia X da Geometria da Camada"@pt-br ,
                                       "Layer Geometry Inertia X"@en ;
-                       :hasAttributeScope :InstanceLevelAttribute ;
-                       :hasTypedValue :floatValue ;
-                       :hasValueCardinality :singleValue .
+                       edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                       edo:hasTypedValue edo:floatValue ;
+                       edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LayerGeometryInertiaY
-:LayerGeometryInertiaY rdf:type owl:Class ;
-                       rdfs:subClassOf :LayerGeometryAttribute ;
+edo:LayerGeometryInertiaY rdf:type owl:Class ;
+                       rdfs:subClassOf edo:LayerGeometryAttribute ;
                        dcterms:accessRights "PUBLIC" ;
                        dcterms:identifier "LayerGeometryInertiaY" ;
                        skos:definition "Indicates the moment of inertia of the layer's geometry around the Y-axis. This property is important for evaluating the layer's resistance to bending or deformation when subjected to forces along the Y-axis, helping to ensure the structural stability and performance of the component."@en ;
                        skos:prefLabel "Inércia  Y da Geometria da Camada"@pt-br ,
                                       "Layer Geometry Inertia Y"@en ;
-                       :hasAttributeScope :InstanceLevelAttribute ;
-                       :hasTypedValue :floatValue ;
-                       :hasValueCardinality :singleValue .
+                       edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                       edo:hasTypedValue edo:floatValue ;
+                       edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LayerGeometryManufacturer
-:LayerGeometryManufacturer rdf:type owl:Class ;
-                           rdfs:subClassOf :LayerGeometryAttribute ;
+edo:LayerGeometryManufacturer rdf:type owl:Class ;
+                           rdfs:subClassOf edo:LayerGeometryAttribute ;
                            dcterms:accessRights "PUBLIC" ;
                            dcterms:identifier "LayerGeometryManufacturer" ;
                            skos:definition "Indicates the manufacturer responsible for producing the layer's geometry. This property is important for tracking the origin and quality of the layer, providing key information about the source of the material or component used in the structure."@en ;
                            skos:prefLabel "Fabricante da Geometria da Camada"@pt-br ,
                                           "Layer Geometry Manufacturer"@en ;
-                           :hasAttributeScope :InstanceLevelAttribute ;
-                           :hasTypedValue :stringValue ;
-                           :hasValueCardinality :singleValue .
+                           edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                           edo:hasTypedValue edo:stringValue ;
+                           edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LayerGeometryName
-:LayerGeometryName rdf:type owl:Class ;
-                   rdfs:subClassOf :LayerGeometryAttribute ;
+edo:LayerGeometryName rdf:type owl:Class ;
+                   rdfs:subClassOf edo:LayerGeometryAttribute ;
                    dcterms:accessRights "PUBLIC" ;
                    dcterms:identifier "LayerGeometryName" ;
                    skos:definition "Indicates the name assigned to the layer's geometry. This property is used to identify and distinguish the specific geometry of the layer, helping with organization, tracking, and reference within the overall structure or design."@en ;
                    skos:prefLabel "Layer Geometry Name"@en ,
                                   "Nome da Geometria da Camada"@pt-br ;
-                   :hasAttributeScope :InstanceLevelAttribute ;
-                   :hasTypedValue :stringValue ;
-                   :hasValueCardinality :singleValue .
+                   edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                   edo:hasTypedValue edo:stringValue ;
+                   edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LayerGeometryProfileThickness
-:LayerGeometryProfileThickness rdf:type owl:Class ;
-                               rdfs:subClassOf :LayerGeometryAttribute ;
+edo:LayerGeometryProfileThickness rdf:type owl:Class ;
+                               rdfs:subClassOf edo:LayerGeometryAttribute ;
                                dcterms:accessRights "PUBLIC" ;
                                dcterms:identifier "LayerGeometryProfileThickness" ;
                                skos:definition "Indicates the thickness of the layer's geometric profile. This property is important for understanding the contribution of the layer to the overall structure, particularly in terms of strength, flexibility, and resistance to external forces."@en ;
                                skos:prefLabel "Espessura do Perfil da Geometria da Camada"@pt-br ,
                                               "Layer Geometry Profile Thickness"@en ;
-                               :hasAttributeScope :InstanceLevelAttribute ;
-                               :hasTypedValue :floatValue ;
-                               :hasValueCardinality :singleValue .
+                               edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                               edo:hasTypedValue edo:floatValue ;
+                               edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LayerGeometryProfileWidth
-:LayerGeometryProfileWidth rdf:type owl:Class ;
-                           rdfs:subClassOf :LayerGeometryAttribute ;
+edo:LayerGeometryProfileWidth rdf:type owl:Class ;
+                           rdfs:subClassOf edo:LayerGeometryAttribute ;
                            dcterms:accessRights "PUBLIC" ;
                            dcterms:identifier "LayerGeometryProfileWidth" ;
                            skos:definition "Indicates the width of the layer's geometric profile. This property is important for understanding the dimensions of the layer, contributing to the overall structural design, and influencing factors such as load distribution and mechanical performance."@en ;
                            skos:prefLabel "Largura do Perfil da Geometria da Camada"@pt-br ,
                                           "Layer Geometry Profile Width"@en ;
-                           :hasAttributeScope :InstanceLevelAttribute ;
-                           :hasTypedValue :floatValue ;
-                           :hasValueCardinality :singleValue .
+                           edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                           edo:hasTypedValue edo:floatValue ;
+                           edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LayerGeometryThickness
-:LayerGeometryThickness rdf:type owl:Class ;
-                        rdfs:subClassOf :LayerGeometryAttribute ;
+edo:LayerGeometryThickness rdf:type owl:Class ;
+                        rdfs:subClassOf edo:LayerGeometryAttribute ;
                         dcterms:accessRights "PUBLIC" ;
                         dcterms:identifier "LayerGeometryThickness" ;
                         skos:definition "Indicates the overall thickness of the layer's geometry. This property is critical for evaluating the structural contribution of the layer, including its strength, flexibility, and resistance to external forces."@en ;
                         skos:prefLabel "Espessura da Geometria da Camada"@pt-br ,
                                        "Layer Geometry Thickness"@en ;
-                        :hasAttributeScope :InstanceLevelAttribute ;
-                        :hasTypedValue :floatValue ;
-                        :hasValueCardinality :singleValue .
+                        edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                        edo:hasTypedValue edo:floatValue ;
+                        edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LayerThickness
-:LayerThickness rdf:type owl:Class ;
-                rdfs:subClassOf :DomainAttribute ;
+edo:LayerThickness rdf:type owl:Class ;
+                rdfs:subClassOf edo:DomainAttribute ;
                 dcterms:accessRights "PUBLIC" ;
                 dcterms:identifier "LayerThickness" ;
                 skos:definition "Indicates the thickness of the layer, providing a key dimension that affects the overall strength, flexibility, and performance of the structure. This value is critical for ensuring that the layer meets design requirements and operational conditions."@en ;
                 skos:prefLabel "Espessura da camada"@pt-br ,
                                "Layer Thickness"@en ;
-                :hasAttributeScope :InstanceLevelAttribute ;
-                :hasTypedValue :floatValue ;
-                :hasValueCardinality :singleValue .
+                edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                edo:hasTypedValue edo:floatValue ;
+                edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LayerWatertight
-:LayerWatertight rdf:type owl:Class ;
-                 rdfs:subClassOf :DomainAttribute ;
+edo:LayerWatertight rdf:type owl:Class ;
+                 rdfs:subClassOf edo:DomainAttribute ;
                  dcterms:accessRights "PUBLIC" ;
                  dcterms:identifier "LayerWatertight" ;
                  skos:definition "Indicates whether the layer is designed to be watertight. This property is critical for assessing the layer's ability to prevent water ingress, ensuring protection and maintaining the integrity of the structure in environments where exposure to water or fluids is expected."@en ;
                  skos:prefLabel "Camada Estanque"@pt-br ,
                                 "Layer Watertight"@en ;
-                 :hasAttributeScope :InstanceLevelAttribute ;
-                 :hasTypedValue :booleanValue ;
-                 :hasValueCardinality :singleValue .
+                 edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                 edo:hasTypedValue edo:booleanValue ;
+                 edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LayerWatertightLowerLayerInternalFreeVolume
-:LayerWatertightLowerLayerInternalFreeVolume rdf:type owl:Class ;
-                                             rdfs:subClassOf :DomainAttribute ;
+edo:LayerWatertightLowerLayerInternalFreeVolume rdf:type owl:Class ;
+                                             rdfs:subClassOf edo:DomainAttribute ;
                                              dcterms:accessRights "PUBLIC" ;
                                              dcterms:identifier "LayerWatertightLowerLayerInternalFreeVolume" ;
                                              skos:definition "Indicates the free volume between this layer and the previous continuous or watertight lower layer. If this layer is not watertight, or if there is no previous watertight lower layer, the value should be indicated as zero. This property is important for assessing the space that may affect pressure distribution or fluid movement within the structure."@en ,
                                                              "Volume livre interno entre essa camada e a camada inferior estanque. Se essa camada não for estanque ou caso não tenha camada inferior estanque, indicar zero."@pt-br ;
                                              skos:prefLabel "Layer Watertight Lower Layer Internal Free Volume"@en ,
                                                             "Volume Livre Interno da Camada Inferior Estanque"@pt-br ;
-                                             :hasAttributeScope :InstanceLevelAttribute ;
-                                             :hasTypedValue :floatValue ;
-                                             :hasValueCardinality :singleValue .
+                                             edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                             edo:hasTypedValue edo:floatValue ;
+                                             edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LayingMinimumRadiusTableAttribute
-:LayingMinimumRadiusTableAttribute rdf:type owl:Class ;
-                                   rdfs:subClassOf :DomainAttribute .
+edo:LayingMinimumRadiusTableAttribute rdf:type owl:Class ;
+                                   rdfs:subClassOf edo:DomainAttribute .
 
 
 ###  https://w3id.org/energy-domain/edo#LayingMinimumRadiusTableColumn
-:LayingMinimumRadiusTableColumn rdf:type owl:Class ;
-                                rdfs:subClassOf :LayingMinimumRadiusTableAttribute .
+edo:LayingMinimumRadiusTableColumn rdf:type owl:Class ;
+                                rdfs:subClassOf edo:LayingMinimumRadiusTableAttribute .
 
 
 ###  https://w3id.org/energy-domain/edo#LayingMinimumRadiusTable_AbsoluteExternalPressure
-:LayingMinimumRadiusTable_AbsoluteExternalPressure rdf:type owl:Class ;
-                                                   rdfs:subClassOf :LayingMinimumRadiusTableColumn ;
+edo:LayingMinimumRadiusTable_AbsoluteExternalPressure rdf:type owl:Class ;
+                                                   rdfs:subClassOf edo:LayingMinimumRadiusTableColumn ;
                                                    dcterms:accessRights "PUBLIC" ;
                                                    dcterms:identifier "LayingMinimumRadiusTable_AbsoluteExternalPressure" ;
                                                    skos:definition "Represents the total pressure exerted on a component or system from the external environment, including both atmospheric and hydrostatic pressures. This property is critical for assessing the ability of the system to withstand the full pressure load, ensuring that it maintains structural integrity under extreme conditions."@en ;
                                                    skos:prefLabel "Absolute External Pressure"@en ,
                                                                   "Pressão Externa absoluta"@pt-br ;
-                                                   :hasAttributeScope :TypeLevelAttribute ;
-                                                   :hasTypedValue :floatValue ;
-                                                   :hasValueCardinality :multiValue .
+                                                   edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                                   edo:hasTypedValue edo:floatValue ;
+                                                   edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LayingMinimumRadiusTable_AbsoluteInternalPressure
-:LayingMinimumRadiusTable_AbsoluteInternalPressure rdf:type owl:Class ;
-                                                   rdfs:subClassOf :LayingMinimumRadiusTableColumn ;
+edo:LayingMinimumRadiusTable_AbsoluteInternalPressure rdf:type owl:Class ;
+                                                   rdfs:subClassOf edo:LayingMinimumRadiusTableColumn ;
                                                    dcterms:accessRights "PUBLIC" ;
                                                    dcterms:identifier "LayingMinimumRadiusTable_AbsoluteInternalPressure" ;
                                                    skos:definition "Represents the total pressure exerted inside a component or system, accounting for both the atmospheric pressure and any additional internal pressure. This property is crucial for determining the system's ability to handle internal forces, ensuring safe operation under the expected pressure conditions."@en ;
                                                    skos:prefLabel "Absolute Internal Pressure"@en ,
                                                                   "Pressão interna absoluta"@pt-br ;
-                                                   :hasAttributeScope :TypeLevelAttribute ;
-                                                   :hasTypedValue :floatValue ;
-                                                   :hasValueCardinality :multiValue .
+                                                   edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                                   edo:hasTypedValue edo:floatValue ;
+                                                   edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LayingMinimumRadiusTable_Compression
-:LayingMinimumRadiusTable_Compression rdf:type owl:Class ;
-                                      rdfs:subClassOf :LayingMinimumRadiusTableColumn ;
+edo:LayingMinimumRadiusTable_Compression rdf:type owl:Class ;
+                                      rdfs:subClassOf edo:LayingMinimumRadiusTableColumn ;
                                       dcterms:accessRights "PUBLIC" ;
                                       dcterms:identifier "LayingMinimumRadiusTable_Compression" ;
                                       skos:definition "Nota: Devem ser informados valores negativos. Por exemplo, para uma compressão de 10kN, deve ser informado -10."@pt-br ,
                                                       "Represents the force or stress applied to a material or component that causes it to decrease in size along a particular axis. This property is important for evaluating the material's ability to withstand compressive loads without failure."@en ;
                                       skos:prefLabel "Compression"@en ,
                                                      "Compressão"@pt-br ;
-                                      :hasAttributeScope :TypeLevelAttribute ;
-                                      :hasTypedValue :floatValue ;
-                                      :hasValueCardinality :multiValue .
+                                      edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                      edo:hasTypedValue edo:floatValue ;
+                                      edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LayingMinimumRadiusTable_MinimumAllowableBendingRadius
-:LayingMinimumRadiusTable_MinimumAllowableBendingRadius rdf:type owl:Class ;
-                                                        rdfs:subClassOf :LayingMinimumRadiusTableColumn ;
+edo:LayingMinimumRadiusTable_MinimumAllowableBendingRadius rdf:type owl:Class ;
+                                                        rdfs:subClassOf edo:LayingMinimumRadiusTableColumn ;
                                                         dcterms:accessRights "PUBLIC" ;
                                                         dcterms:identifier "LayingMinimumRadiusTable_MinimumAllowableBendingRadius" ;
                                                         skos:definition "Represents the smallest radius to which a component, such as a pipe or cable, can be bent without causing damage or compromising its structural integrity. This property is essential for determining handling and installation limits to avoid deformation or failure."@en ;
                                                         skos:prefLabel "Minimum Allowable Bending Radius"@en ,
                                                                        "Raio Mínimo de Curvatura Permitido"@pt-br ;
-                                                        :hasAttributeScope :TypeLevelAttribute ;
-                                                        :hasTypedValue :stringValue ;
-                                                        :hasValueCardinality :multiValue .
+                                                        edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                                        edo:hasTypedValue edo:stringValue ;
+                                                        edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LayingMinimumRadiusTable_SectionSupportedByRigidSupport
-:LayingMinimumRadiusTable_SectionSupportedByRigidSupport rdf:type owl:Class ;
-                                                         rdfs:subClassOf :LayingMinimumRadiusTableColumn ;
+edo:LayingMinimumRadiusTable_SectionSupportedByRigidSupport rdf:type owl:Class ;
+                                                         rdfs:subClassOf edo:LayingMinimumRadiusTableColumn ;
                                                          dcterms:accessRights "PUBLIC" ;
                                                          dcterms:identifier "LayingMinimumRadiusTable_SectionSupportedByRigidSupport" ;
                                                          skos:definition "Indicates whether the section is supported by a rigid support (TRUE) or not (FALSE)."@en ;
                                                          skos:prefLabel "Section Supported By Rigid Support"@en ,
                                                                         "Seção Suportada por um Suporte Rígido"@pt-br ;
-                                                         :hasAttributeScope :TypeLevelAttribute ;
-                                                         :hasTypedValue :booleanValue ;
-                                                         :hasValueCardinality :multiValue .
+                                                         edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                                         edo:hasTypedValue edo:booleanValue ;
+                                                         edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LayingMinimumRadiusTable_TensileArmourAnnulusCondition
-:LayingMinimumRadiusTable_TensileArmourAnnulusCondition rdf:type owl:Class ;
-                                                        rdfs:subClassOf :LayingMinimumRadiusTableColumn ;
+edo:LayingMinimumRadiusTable_TensileArmourAnnulusCondition rdf:type owl:Class ;
+                                                        rdfs:subClassOf edo:LayingMinimumRadiusTableColumn ;
                                                         dcterms:accessRights "PUBLIC" ;
                                                         dcterms:identifier "LayingMinimumRadiusTable_TensileArmourAnnulusCondition" ;
                                                         skos:definition "Condição do anular das armaduras de tração, Alagado ou Seco"@pt-br ,
                                                                         "Indicates the condition of the annulus in the tensile armour layer, which refers to the space between the tensile armour and other layers."@en ;
                                                         skos:prefLabel "Condição do Anular das Armaduras de Tração"@pt-br ,
                                                                        "Tensile Armour Annulus Condition"@en ;
-                                                        :hasAttributeScope :TypeLevelAttribute ;
-                                                        :hasTypedValue :stringValue ;
-                                                        :hasValueCardinality :multiValue .
+                                                        edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                                        edo:hasTypedValue edo:stringValue ;
+                                                        edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LifecyclePhase
-:LifecyclePhase rdf:type owl:Class ;
-                rdfs:subClassOf :AttributeClassification ;
+edo:LifecyclePhase rdf:type owl:Class ;
+                rdfs:subClassOf edo:AttributeClassification ;
                 rdfs:comment "Represents a stage in the lifecycle of an industrial asset."@en ;
                 rdfs:label "Fase do Ciclo de Vida"@pt-br ,
                            "Lifecycle Phase"@en ;
@@ -3476,22 +3475,22 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#LimpTorsionalStiffnessAtSeaLevel
-:LimpTorsionalStiffnessAtSeaLevel rdf:type owl:Class ;
-                                  rdfs:subClassOf :DomainAttribute ;
+edo:LimpTorsionalStiffnessAtSeaLevel rdf:type owl:Class ;
+                                  rdfs:subClassOf edo:DomainAttribute ;
                                   dcterms:accessRights "PUBLIC" ;
                                   dcterms:identifier "LimpTorsionalStiffnessAtSeaLevel" ;
                                   skos:definition "Indicates the torsional stiffness of the structure when in a limp or flexible state at sea level conditions. This value is important for assessing how the structure resists twisting forces while maintaining flexibility during operations at sea level."@en ,
                                                   "Rigidez a torção (GJ) (menor valor) a 20°C e pressão atmosferica (dentro e fora)"@pt-br ;
                                   skos:prefLabel "Limp Torsional Stiffness At Sea Level"@en ,
                                                  "Rigidez à Torção em Estado Flexível ao Nível do Mar"@pt-br ;
-                                  :hasAttributeScope :TypeLevelAttribute ;
-                                  :hasTypedValue :floatValue ;
-                                  :hasValueCardinality :singleValue .
+                                  edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                  edo:hasTypedValue edo:floatValue ;
+                                  edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LineAncillary
-:LineAncillary rdf:type owl:Class ;
-               rdfs:subClassOf :Component ;
+edo:LineAncillary rdf:type owl:Class ;
+               rdfs:subClassOf edo:Component ;
                dcterms:identifier "LineAncillary" ;
                skos:definition "A component designed to complement and enhance the functionality of subsea flexible pipes. Line Ancillaries include a variety of parts such as connectors, clamps, or collars that facilitate the installation, operation, and maintenance of flexible pipes used in subsea systems. These ancillaries ensure proper alignment, secure connections, and protection against environmental factors, contributing to the reliable performance and integrity of the flexible pipe system in harsh underwater conditions."@en ;
                skos:prefLabel "Acessório de Linha"@pt-br ,
@@ -3499,14 +3498,14 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#LineSpan
-:LineSpan rdf:type owl:Class ;
-          rdfs:subClassOf :Location ;
+edo:LineSpan rdf:type owl:Class ;
+          rdfs:subClassOf edo:Location ;
           dcterms:identifier "LineSpan" .
 
 
 ###  https://w3id.org/energy-domain/edo#LineTermination
-:LineTermination rdf:type owl:Class ;
-                 rdfs:subClassOf :ComponentDevice ;
+edo:LineTermination rdf:type owl:Class ;
+                 rdfs:subClassOf edo:ComponentDevice ;
                  dcterms:identifier "LineTermination" ;
                  skos:definition "The Line Termination includes components at the endpoints of flexible and rigid pipelines, as well as umbilical systems. These terminations provide secure connections to other equipment, enabling the transfer of fluids, gases, or control signals. Designed for stability and integrity, Line Termination components ensure durable and reliable performance across various pipeline types."@en ;
                  skos:prefLabel "Line Termination"@en ,
@@ -3514,14 +3513,14 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#LineTerminationModule
-:LineTerminationModule rdf:type owl:Class ;
-                       rdfs:subClassOf :TieInEquipment ;
+edo:LineTerminationModule rdf:type owl:Class ;
+                       rdfs:subClassOf edo:TieInEquipment ;
                        dcterms:identifier "LineTerminationModule" .
 
 
 ###  https://w3id.org/energy-domain/edo#LinearLocation
-:LinearLocation rdf:type owl:Class ;
-                rdfs:subClassOf :Location ;
+edo:LinearLocation rdf:type owl:Class ;
+                rdfs:subClassOf edo:Location ;
                 dcterms:identifier "LinearLocation" ;
                 skos:definition "Base for locations that extend along a geographically significant route."@en ;
                 skos:prefLabel "Linear Location"@en ,
@@ -3529,22 +3528,22 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#LinearMass
-:LinearMass rdf:type owl:Class ;
-            rdfs:subClassOf :DomainAttribute ;
+edo:LinearMass rdf:type owl:Class ;
+            rdfs:subClassOf edo:DomainAttribute ;
             dcterms:accessRights "PUBLIC" ;
             dcterms:identifier "LinearMass" ;
             skos:definition "Indicates the mass per unit length, providing essential information for weight distribution and load calculations. This value is critical for evaluating how the structure will perform under various operational conditions, including installation and transport."@en ;
             skos:prefLabel "Linear Mass"@en ,
                            "Massa Linear"@pt-br ;
-            :hasAttributeScope :InstanceLevelAttribute ,
-                               :TypeLevelAttribute ;
-            :hasTypedValue :floatValue ;
-            :hasValueCardinality :singleValue .
+            edo:hasAttributeScope edo:InstanceLevelAttribute ,
+                               edo:TypeLevelAttribute ;
+            edo:hasTypedValue edo:floatValue ;
+            edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LinearObject
-:LinearObject rdf:type owl:Class ;
-              rdfs:subClassOf :Asset ;
+edo:LinearObject rdf:type owl:Class ;
+              rdfs:subClassOf edo:Asset ;
               dcterms:identifier "LinearObject" ;
               skos:definition "Base for any type of interconnecting element with linear geometry."@en ;
               skos:prefLabel "Linear Object"@en ,
@@ -3552,8 +3551,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#Location
-:Location rdf:type owl:Class ;
-          rdfs:subClassOf :DomainElement ;
+edo:Location rdf:type owl:Class ;
+          rdfs:subClassOf edo:DomainElement ;
           dcterms:identifier "Location" ;
           skos:definition "Basis for all model installation locations."@en ;
           skos:prefLabel "Localização"@pt-br ,
@@ -3561,8 +3560,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#LocationType
-:LocationType rdf:type owl:Class ;
-              rdfs:subClassOf :ElementClassification ;
+edo:LocationType rdf:type owl:Class ;
+              rdfs:subClassOf edo:ElementClassification ;
               rdfs:label "Location Type"@en ,
                          "Tipo de Localização"@pt-br ;
               skos:definition "Classification of industrial activities based on their geographical location."@en ,
@@ -3570,14 +3569,14 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#LogicCap
-:LogicCap rdf:type owl:Class ;
-          rdfs:subClassOf :AuxiliaryModule ;
+edo:LogicCap rdf:type owl:Class ;
+          rdfs:subClassOf edo:AuxiliaryModule ;
           dcterms:identifier "LogicCap" .
 
 
 ###  https://w3id.org/energy-domain/edo#LogicalConnection
-:LogicalConnection rdf:type owl:Class ;
-                   rdfs:subClassOf :Connection ;
+edo:LogicalConnection rdf:type owl:Class ;
+                   rdfs:subClassOf edo:Connection ;
                    dcterms:identifier "LogicalConnection" ;
                    skos:definition "Represents a logical/functional connection between two installation locations."@en ;
                    skos:prefLabel "Conexão Lógica"@pt-br ,
@@ -3585,74 +3584,74 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#LongTermFloatDensity
-:LongTermFloatDensity rdf:type owl:Class ;
-                      rdfs:subClassOf :DomainAttribute ;
+edo:LongTermFloatDensity rdf:type owl:Class ;
+                      rdfs:subClassOf edo:DomainAttribute ;
                       dcterms:accessRights "PUBLIC" ;
                       dcterms:identifier "LongTermFloatDensity" ;
                       skos:definition "A densidade do flutuador ao longo do tempo, considerando o acúmulo de água no material ou mudanças na estrutura interna devido à degradação. Isso aumenta a densidade e, portanto, reduz a flutuabilidade"@pt-br ,
                                       "The density of the float material over time, considering factors like water absorption and material degradation, which increase the density and reduce the buoyancy."@en ;
                       skos:prefLabel "Densidade do Flutuador a Longo Prazo"@pt-br ,
                                      "Long Term Float Density"@en ;
-                      :hasAttributeScope :TypeLevelAttribute ;
-                      :hasTypedValue :floatValue ;
-                      :hasValueCardinality :singleValue .
+                      edo:hasAttributeScope edo:TypeLevelAttribute ;
+                      edo:hasTypedValue edo:floatValue ;
+                      edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LongTermFloatVolume
-:LongTermFloatVolume rdf:type owl:Class ;
-                     rdfs:subClassOf :DomainAttribute ;
+edo:LongTermFloatVolume rdf:type owl:Class ;
+                     rdfs:subClassOf edo:DomainAttribute ;
                      dcterms:accessRights "PUBLIC" ;
                      dcterms:identifier "LongTermFloatVolume" ;
                      skos:definition "O volume esperado ao longo do tempo, após fatores como absorção de água e possíveis deformações. Este volume representa as condições do flutuador em sua fase de vida útil, quando a flutuabilidade tende a ser menor."@pt-br ,
                                      "The expected submerged volume of the float over time, taking into account factors like water absorption and structural deformations that may occur throughout its lifecycle."@en ;
                      skos:prefLabel "Long Term Float Volume"@en ,
                                     "Volume do Flutuador a Longo Prazo"@pt-br ;
-                     :hasAttributeScope :TypeLevelAttribute ;
-                     :hasTypedValue :floatValue ;
-                     :hasValueCardinality :singleValue .
+                     edo:hasAttributeScope edo:TypeLevelAttribute ;
+                     edo:hasTypedValue edo:floatValue ;
+                     edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LowResistanceTape
-:LowResistanceTape rdf:type owl:Class ;
-                   rdfs:subClassOf :TapeLayer ;
+edo:LowResistanceTape rdf:type owl:Class ;
+                   rdfs:subClassOf edo:TapeLayer ;
                    dcterms:identifier "LowResistanceTape" ;
                    skos:definition "A layer used in subsea flexible pipes to reduce friction between different components or layers, enhancing the overall flexibility and durability of the pipe. The Low Resistance Tape minimizes wear and abrasion caused by the movement of adjacent layers during operation, particularly in dynamic subsea conditions. Made from materials with low friction properties, it helps extend the lifespan of the pipe by reducing internal stresses and preventing damage to critical layers, ensuring smooth and efficient operation under harsh underwater conditions."@en ;
                    skos:prefLabel "Fita de Baixa Resistência"@pt-br ,
                                   "Low Resistance Tape"@en ;
-                   :ifc_equivalentClass "IfcPipeSegment" ;
-                   :ifc_objectType "LowResistanceTape" ;
-                   :ifc_predefinedType "USERDEFINED" .
+                   edo:ifc_equivalentClass "IfcPipeSegment" ;
+                   edo:ifc_objectType "LowResistanceTape" ;
+                   edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#Lubricant
-:Lubricant rdf:type owl:Class ;
-           rdfs:subClassOf :DomainAttribute ;
+edo:Lubricant rdf:type owl:Class ;
+           rdfs:subClassOf edo:DomainAttribute ;
            dcterms:accessRights "PUBLIC" ;
            dcterms:identifier "Lubricant" ;
            skos:definition "Specifies the type of lubricant applied to reduce friction during tightening and ensure consistent torque application. The use of the correct lubricant is critical in preventing galling and corrosion, and helps to maintain the long-term integrity."@en ;
            skos:prefLabel "Lubricant"@en ,
                           "Nome do Lubrificante"@pt-br ;
-           :hasAttributeScope :InstanceLevelAttribute ;
-           :hasTypedValue :stringValue ;
-           :hasValueCardinality :singleValue .
+           edo:hasAttributeScope edo:InstanceLevelAttribute ;
+           edo:hasTypedValue edo:stringValue ;
+           edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#LubricantFrictionFactor
-:LubricantFrictionFactor rdf:type owl:Class ;
-                         rdfs:subClassOf :DomainAttribute ;
+edo:LubricantFrictionFactor rdf:type owl:Class ;
+                         rdfs:subClassOf edo:DomainAttribute ;
                          dcterms:accessRights "PUBLIC" ;
                          dcterms:identifier "LubricantFrictionFactor" ;
                          skos:definition "Indicates the friction factor of the lubricant applied, which affects the torque required to achieve proper tightening. This value is crucial for ensuring that the correct amount of torque is applied, accounting for the reduction in friction caused by the lubricant."@en ;
                          skos:prefLabel "Fator de atrito do lubrificante"@pt-br ,
                                         "Lubricant Friction Factor"@en ;
-                         :hasAttributeScope :InstanceLevelAttribute ;
-                         :hasTypedValue :floatValue ;
-                         :hasValueCardinality :singleValue .
+                         edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                         edo:hasTypedValue edo:floatValue ;
+                         edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#Maintenance
-:Maintenance rdf:type owl:Class ;
-             rdfs:subClassOf :LifecyclePhase ;
+edo:Maintenance rdf:type owl:Class ;
+             rdfs:subClassOf edo:LifecyclePhase ;
              rdfs:label "Maintenance"@en ,
                         "Manutenção"@pt-br ;
              skos:definition "Intervenções planejadas ou corretivas para preservar a funcionalidade e segurança do ativo."@pt-br ,
@@ -3660,375 +3659,375 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#Manifold
-:Manifold rdf:type owl:Class ;
-          rdfs:subClassOf :FlowControlEquipment ;
+edo:Manifold rdf:type owl:Class ;
+          rdfs:subClassOf edo:FlowControlEquipment ;
           dcterms:identifier "Manifold" .
 
 
 ###  https://w3id.org/energy-domain/edo#ManufacturerDefinedMaterialName
-:ManufacturerDefinedMaterialName rdf:type owl:Class ;
-                                 rdfs:subClassOf :MaterialManufacturerAttribute ;
+edo:ManufacturerDefinedMaterialName rdf:type owl:Class ;
+                                 rdfs:subClassOf edo:MaterialManufacturerAttribute ;
                                  dcterms:accessRights "PUBLIC" ;
                                  dcterms:identifier "ManufacturerDefinedMaterialName" ;
                                  skos:definition "Name of the material as designated by the manufacturer of the final item. This property identifies the specific material name used by the manufacturer, providing clarity on the material specifications for the finished accessory."@en ;
                                  skos:prefLabel "Manufacturer Defined Material Name"@en ,
                                                 "Nome do material conforme designado pelo fabricante do item final"@pt-br ;
-                                 :hasAttributeScope :TypeLevelAttribute ;
-                                 :hasTypedValue :stringValue ;
-                                 :hasValueCardinality :multiValue .
+                                 edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                 edo:hasTypedValue edo:stringValue ;
+                                 edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#ManufacturingDate
-:ManufacturingDate rdf:type owl:Class ;
-                   rdfs:subClassOf :DomainAttribute ;
+edo:ManufacturingDate rdf:type owl:Class ;
+                   rdfs:subClassOf edo:DomainAttribute ;
                    dcterms:accessRights "PUBLIC" ;
                    dcterms:identifier "ManufacturingDate" ;
                    skos:definition "Manufacturing date refers to the specific date when an object or product was produced or fabricated. This information is essential for tracking production batches, ensuring quality control, and determining the product’s shelf life or warranty period."@en ;
                    skos:prefLabel "Data de Fabricação"@pt-br ,
                                   "Manufacturing Date"@en ;
-                   :hasAttributeScope :InstanceLevelAttribute ;
-                   :hasTypedValue :stringValue ;
-                   :hasValueCardinality :singleValue .
+                   edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                   edo:hasTypedValue edo:stringValue ;
+                   edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#ManufacturingNonConformities
-:ManufacturingNonConformities rdf:type owl:Class ;
-                              rdfs:subClassOf :DomainAttribute ;
+edo:ManufacturingNonConformities rdf:type owl:Class ;
+                              rdfs:subClassOf edo:DomainAttribute ;
                               dcterms:accessRights "PUBLIC" ;
                               dcterms:identifier "ManufacturingNonConformities" ;
                               skos:definition "Indicates whether the item has manufacturing non-conformities (TRUE) or not (FALSE)."@en ;
                               skos:prefLabel "Manufacturing Non Conformities"@en ,
                                              "Não Conformidades de Fabricação"@pt-br ;
-                              :hasAttributeScope :InstanceLevelAttribute ;
-                              :hasTypedValue :booleanValue ;
-                              :hasValueCardinality :singleValue .
+                              edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                              edo:hasTypedValue edo:booleanValue ;
+                              edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#Mass
-:Mass rdf:type owl:Class ;
-      rdfs:subClassOf :DomainAttribute ;
+edo:Mass rdf:type owl:Class ;
+      rdfs:subClassOf edo:DomainAttribute ;
       dcterms:accessRights "PUBLIC" ;
       dcterms:identifier "Mass" ;
       skos:definition "Amount of matter that makes up an object."@en ;
       skos:prefLabel "Mass"@en ,
                      "Massa"@pt-br ;
-      :hasAttributeScope :TypeLevelAttribute ;
-      :hasTypedValue :floatValue ;
-      :hasValueCardinality :singleValue .
+      edo:hasAttributeScope edo:TypeLevelAttribute ;
+      edo:hasTypedValue edo:floatValue ;
+      edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MasterControlStation
-:MasterControlStation rdf:type owl:Class ;
-                      rdfs:subClassOf :TopsideEquipment ;
+edo:MasterControlStation rdf:type owl:Class ;
+                      rdfs:subClassOf edo:TopsideEquipment ;
                       dcterms:identifier "MasterControlStation" .
 
 
 ###  https://w3id.org/energy-domain/edo#MaterialComposition
-:MaterialComposition rdf:type owl:Class ;
-                     rdfs:subClassOf :DomainAttribute ;
+edo:MaterialComposition rdf:type owl:Class ;
+                     rdfs:subClassOf edo:DomainAttribute ;
                      dcterms:accessRights "PUBLIC" ;
                      dcterms:identifier "MaterialComposition" ;
                      skos:definition "Indicates the composition of the fabrication material used. This property provides details about the specific material, helping to assess its mechanical, thermal, and chemical properties. It is crucial for evaluating the material's suitability for various operational conditions and services."@en ,
                                      "Tipo do material."@pt-br ;
                      skos:prefLabel "Composição do Material"@pt-br ,
                                     "Material Composition"@en ;
-                     :hasAttributeScope :TypeLevelAttribute ;
-                     :hasTypedValue :stringValue ;
-                     :hasValueCardinality :singleValue .
+                     edo:hasAttributeScope edo:TypeLevelAttribute ;
+                     edo:hasTypedValue edo:stringValue ;
+                     edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MaterialManufacturerAttribute
-:MaterialManufacturerAttribute rdf:type owl:Class ;
-                               rdfs:subClassOf :DomainAttribute ;
+edo:MaterialManufacturerAttribute rdf:type owl:Class ;
+                               rdfs:subClassOf edo:DomainAttribute ;
                                rdfs:label "Material Manufacturer"@en .
 
 
 ###  https://w3id.org/energy-domain/edo#MaterialRequest
-:MaterialRequest rdf:type owl:Class ;
-                 rdfs:subClassOf :DomainAttribute ;
+edo:MaterialRequest rdf:type owl:Class ;
+                 rdfs:subClassOf edo:DomainAttribute ;
                  dcterms:accessRights "PUBLIC" ;
                  dcterms:identifier "MaterialRequest" ;
                  skos:definition "Code used to identify the document that specifies the materials required for the project, serving as the basis for generating the purchase order. It ensures accurate tracking and procurement of necessary items for project execution."@en ;
                  skos:prefLabel "Código da Requisição de Material (RM)"@pt-br ,
                                 "Material Request"@en ;
-                 :hasAttributeScope :InstanceLevelAttribute ;
-                 :hasTypedValue :stringValue ;
-                 :hasValueCardinality :singleValue .
+                 edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                 edo:hasTypedValue edo:stringValue ;
+                 edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MaterialRequestRev
-:MaterialRequestRev rdf:type owl:Class ;
-                    rdfs:subClassOf :DomainAttribute ;
+edo:MaterialRequestRev rdf:type owl:Class ;
+                    rdfs:subClassOf edo:DomainAttribute ;
                     dcterms:accessRights "PUBLIC" ;
                     dcterms:identifier "MaterialRequestRev" ;
                     skos:definition "Indicates the revision number of the Material Request document, ensuring that the most up-to-date version is referenced during procurement and project execution."@en ;
                     skos:prefLabel "Material Request Revision"@en ,
                                    "Revisão da Requisição de Material (RM)"@pt-br ;
-                    :hasAttributeScope :InstanceLevelAttribute ;
-                    :hasTypedValue :stringValue ;
-                    :hasValueCardinality :singleValue .
+                    edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                    edo:hasTypedValue edo:stringValue ;
+                    edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MaterialSupplierName
-:MaterialSupplierName rdf:type owl:Class ;
-                      rdfs:subClassOf :MaterialManufacturerAttribute ;
+edo:MaterialSupplierName rdf:type owl:Class ;
+                      rdfs:subClassOf edo:MaterialManufacturerAttribute ;
                       dcterms:accessRights "PUBLIC" ;
                       dcterms:identifier "MaterialSupplierName" ;
                       skos:definition "Name of the company responsible for supplying the material. This property identifies the supplier of the material used in the accessory, ensuring traceability and accountability."@en ;
                       skos:prefLabel "Material Supplier Name"@en ,
                                      "Nome da empresa responsável por fornecer o material"@pt-br ;
-                      :hasAttributeScope :TypeLevelAttribute ;
-                      :hasTypedValue :stringValue ;
-                      :hasValueCardinality :singleValue .
+                      edo:hasAttributeScope edo:TypeLevelAttribute ;
+                      edo:hasTypedValue edo:stringValue ;
+                      edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#Mattress
-:Mattress rdf:type owl:Class ;
-          rdfs:subClassOf :PipeSupport ;
+edo:Mattress rdf:type owl:Class ;
+          rdfs:subClassOf edo:PipeSupport ;
           dcterms:identifier "Mattress" .
 
 
 ###  https://w3id.org/energy-domain/edo#MaxDesignAbsIntPresTable
-:MaxDesignAbsIntPresTable rdf:type owl:Class ;
-                          rdfs:subClassOf :DomainAttribute ;
+edo:MaxDesignAbsIntPresTable rdf:type owl:Class ;
+                          rdfs:subClassOf edo:DomainAttribute ;
                           dcterms:accessRights "PUBLIC" ;
                           dcterms:identifier "MaxDesignAbsIntPresTable" ;
                           skos:definition "Provides data on the maximum design absolute internal pressure, used to evaluate the highest internal pressure the structure is designed to withstand. This information is critical for ensuring the structure's integrity and safety under the most demanding operational conditions."@en ;
                           skos:prefLabel "Maximum Design Absolute Internal Pressure Table"@en ,
                                          "Tabela da Máxima Pressão Interna Absoluta de Projeto"@pt-br ;
-                          :hasAttributeScope :InstanceLevelAttribute .
+                          edo:hasAttributeScope edo:InstanceLevelAttribute .
 
 
 ###  https://w3id.org/energy-domain/edo#MaxDesignAbsIntPresTable_PositionReference
-:MaxDesignAbsIntPresTable_PositionReference rdf:type owl:Class ;
-                                            rdfs:subClassOf :MaxDesignAbsIntPresTable ;
+edo:MaxDesignAbsIntPresTable_PositionReference rdf:type owl:Class ;
+                                            rdfs:subClassOf edo:MaxDesignAbsIntPresTable ;
                                             dcterms:accessRights "PUBLIC" ;
                                             dcterms:identifier "MaxDesignAbsIntPresTable_PositionReference" ;
                                             skos:definition "Identifies the specific point along the pipeline, such as the topside connection, TDP (Touchdown Point), or subsea connection point. This serves as the reference for vertical position and pressure values."@en ,
                                                             "Ponto. Valores válidos:Top (Para a conexão topside - E.g. Conector superior)TDPSubSeaConnection (Ex. ANM)"@pt-br ;
                                             skos:prefLabel "Position Reference"@en ,
                                                            "Referência de Posição"@pt-br ;
-                                            :hasAttributeScope :InstanceLevelAttribute ;
-                                            :hasTypedValue :stringValue ;
-                                            :hasValueCardinality :multiValue .
+                                            edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                            edo:hasTypedValue edo:stringValue ;
+                                            edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MaxDesignAbsIntPresTable_Pressure
-:MaxDesignAbsIntPresTable_Pressure rdf:type owl:Class ;
-                                   rdfs:subClassOf :MaxDesignAbsIntPresTable ;
+edo:MaxDesignAbsIntPresTable_Pressure rdf:type owl:Class ;
+                                   rdfs:subClassOf edo:MaxDesignAbsIntPresTable ;
                                    dcterms:accessRights "PUBLIC" ;
                                    dcterms:identifier "MaxDesignAbsIntPresTable_Pressure" ;
                                    skos:definition "Indicates the force exerted per unit area on the surface of a material or component. This property is critical for evaluating how the component responds to external or internal forces, ensuring it can withstand operational pressure conditions."@en ;
                                    skos:prefLabel "Maximum Design Absolute Internal Pressure"@en ,
                                                   "Máxima Pressão Interna Absoluta de Projeto"@pt-br ;
-                                   :hasAttributeScope :InstanceLevelAttribute ;
-                                   :hasTypedValue :floatValue ;
-                                   :hasValueCardinality :multiValue .
+                                   edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                   edo:hasTypedValue edo:floatValue ;
+                                   edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MaxDesignAbsIntPresTable_VPosWRTWaterline
-:MaxDesignAbsIntPresTable_VPosWRTWaterline rdf:type owl:Class ;
-                                           rdfs:subClassOf :MaxDesignAbsIntPresTable ;
+edo:MaxDesignAbsIntPresTable_VPosWRTWaterline rdf:type owl:Class ;
+                                           rdfs:subClassOf edo:MaxDesignAbsIntPresTable ;
                                            dcterms:accessRights "PUBLIC" ;
                                            dcterms:identifier "MaxDesignAbsIntPresTable_VPosWRTWaterline" ;
                                            skos:definition "Valores negativos para pontos submersos, e valores positivos para pontos acima da água. Considerando calado máximo da plataforma, quando aplicável."@pt-br ,
                                                            "Vertical position with respect to the waterline, where positive values indicate points above the water and negative values indicate points below. The platform's maximum draft is considered when applicable."@en ;
                                            skos:prefLabel "Posição Vertical em Relação à Linha D'Água"@pt-br ,
                                                           "Vertical Position With Respect To Waterline"@en ;
-                                           :hasAttributeScope :InstanceLevelAttribute ;
-                                           :hasTypedValue :intValue ;
-                                           :hasValueCardinality :multiValue .
+                                           edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                           edo:hasTypedValue edo:intValue ;
+                                           edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MaxDesignPressure
-:MaxDesignPressure rdf:type owl:Class ;
-                   rdfs:subClassOf :DomainAttribute ;
+edo:MaxDesignPressure rdf:type owl:Class ;
+                   rdfs:subClassOf edo:DomainAttribute ;
                    dcterms:accessRights "PUBLIC" ;
                    dcterms:identifier "MaxDesignPressure" ;
                    skos:definition "The highest internal or external pressure that the component or system is designed to withstand under operational conditions, ensuring safety and reliability."@en ;
                    skos:prefLabel "Maximum Design Pressure"@en ,
                                   "Pressão Máxima de Projeto"@pt-br ;
-                   :hasAttributeScope :TypeLevelAttribute ;
-                   :hasTypedValue :floatValue ;
-                   :hasValueCardinality :singleValue .
+                   edo:hasAttributeScope edo:TypeLevelAttribute ;
+                   edo:hasTypedValue edo:floatValue ;
+                   edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MaxDynamicLoad
-:MaxDynamicLoad rdf:type owl:Class ;
-                rdfs:subClassOf :DomainAttribute ;
+edo:MaxDynamicLoad rdf:type owl:Class ;
+                rdfs:subClassOf edo:DomainAttribute ;
                 dcterms:accessRights "PUBLIC" ;
                 dcterms:identifier "MaxDynamicLoad" ;
                 skos:definition "Maximum Dynamic Load (MDL) that the component can endure during operation. This value indicates the highest load the component can support while experiencing varying forces or impacts. Understanding this limit is essential for ensuring the component’s safety, reliability, and structural integrity in dynamic environments."@en ;
                 skos:prefLabel "Carga Dinâmica Máxima (MDL)"@pt-br ,
                                "Maximum Dynamic Load (MDL)"@en ;
-                :hasAttributeScope :TypeLevelAttribute ;
-                :hasTypedValue :floatValue ;
-                :hasValueCardinality :singleValue .
+                edo:hasAttributeScope edo:TypeLevelAttribute ;
+                edo:hasTypedValue edo:floatValue ;
+                edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MaxLengthTolerance
-:MaxLengthTolerance rdf:type owl:Class ;
-                    rdfs:subClassOf :DomainAttribute ;
+edo:MaxLengthTolerance rdf:type owl:Class ;
+                    rdfs:subClassOf edo:DomainAttribute ;
                     dcterms:accessRights "PUBLIC" ;
                     dcterms:identifier "MaxLengthTolerance" ;
                     skos:definition "Max length tolerance refers to the maximum allowable deviation from the specified or nominal length of an object. It defines the upper limit of acceptable variance during manufacturing or inspection, ensuring that the length stays within the defined range for quality control and compliance with design specifications."@en ;
                     skos:prefLabel "Maximum Length Tolerance"@en ,
                                    "Tolerância Máxima de Comprimento"@pt-br ;
-                    :hasAttributeScope :InstanceLevelAttribute ;
-                    :hasTypedValue :floatValue ;
-                    :hasValueCardinality :singleValue .
+                    edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                    edo:hasTypedValue edo:floatValue ;
+                    edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MaxPermissibleDeformationDynamic
-:MaxPermissibleDeformationDynamic rdf:type owl:Class ;
-                                  rdfs:subClassOf :DomainAttribute ;
+edo:MaxPermissibleDeformationDynamic rdf:type owl:Class ;
+                                  rdfs:subClassOf edo:DomainAttribute ;
                                   dcterms:accessRights "PUBLIC" ;
                                   dcterms:identifier "MaxPermissibleDeformationDynamic" ;
                                   skos:definition "Maximum deformation that the material can undergo under dynamic loading conditions is specified. This property is crucial for assessing how the material will behave when subjected to varying forces or impacts, ensuring it maintains functionality and structural integrity without excessive deformation or failure."@en ,
                                                   "Máxima Deformação Admissível (Aplicações Dinâmicas) (Específica para Materiais Poliméricos)"@pt-br ;
                                   skos:prefLabel "Maximum Permissible Deformation Dynamic"@en ,
                                                  "Máxima Deformação Admissível"@pt-br ;
-                                  :hasAttributeScope :TypeLevelAttribute ;
-                                  :hasTypedValue :floatValue ;
-                                  :hasValueCardinality :singleValue .
+                                  edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                  edo:hasTypedValue edo:floatValue ;
+                                  edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MaxPermissibleDeformationStatic
-:MaxPermissibleDeformationStatic rdf:type owl:Class ;
-                                 rdfs:subClassOf :DomainAttribute ;
+edo:MaxPermissibleDeformationStatic rdf:type owl:Class ;
+                                 rdfs:subClassOf edo:DomainAttribute ;
                                  dcterms:accessRights "PUBLIC" ;
                                  dcterms:identifier "MaxPermissibleDeformationStatic" ;
                                  skos:definition "Indicates the maximum deformation the material can tolerate under static loading conditions. This property defines the extent to which the material can be deformed without failure or significant structural compromise when subjected to constant, non-varying forces or loads."@en ,
                                                  "Máxima Deformação Admissível (Aplicações Estáticas) (Específica para Materiais Poliméricos)"@pt-br ;
                                  skos:prefLabel "Maximum Permissible Deformation Static"@en ,
                                                 "Máxima Deformação Admissível em Aplicações Estáticas"@pt-br ;
-                                 :hasAttributeScope :TypeLevelAttribute ;
-                                 :hasTypedValue :floatValue ;
-                                 :hasValueCardinality :singleValue .
+                                 edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                 edo:hasTypedValue edo:floatValue ;
+                                 edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MaximumAllowableTensileForStraightLine
-:MaximumAllowableTensileForStraightLine rdf:type owl:Class ;
-                                        rdfs:subClassOf :DomainAttribute ;
+edo:MaximumAllowableTensileForStraightLine rdf:type owl:Class ;
+                                        rdfs:subClassOf edo:DomainAttribute ;
                                         dcterms:accessRights "PUBLIC" ;
                                         dcterms:identifier "MaximumAllowableTensileForStraightLine" ;
                                         skos:definition "MaximumAllowableTensileForStraightLine refers to the highest tensile force that can be applied to the flexible pipe in a straight-line configuration without risking damage or compromising the structural integrity of the pipe. This property is critical during installation and operation, ensuring that the pipe can withstand axial loads without overstressing or damaging its internal layers, such as the tensile armour, while maintaining safe handling limits."@en ;
                                         skos:prefLabel "Maximum Allowable Tensile For Straight Line"@en ,
                                                        "Tração Máxima Permitida para Linha Reta"@pt-br ;
-                                        :hasAttributeScope :TypeLevelAttribute ;
-                                        :hasTypedValue :floatValue ;
-                                        :hasValueCardinality :singleValue .
+                                        edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                        edo:hasTypedValue edo:floatValue ;
+                                        edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MaximumAllowableTensionTable_MaximumAllowableTensile
-:MaximumAllowableTensionTable_MaximumAllowableTensile rdf:type owl:Class ;
-                                                      rdfs:subClassOf :CrushingMaximumAllowableTensionTableColumn ;
+edo:MaximumAllowableTensionTable_MaximumAllowableTensile rdf:type owl:Class ;
+                                                      rdfs:subClassOf edo:CrushingMaximumAllowableTensionTableColumn ;
                                                       dcterms:accessRights "PUBLIC" ;
                                                       dcterms:identifier "MaximumAllowableTensionTable_MaximumAllowableTensile" ;
                                                       skos:definition "Indicates the highest tensile force a component can safely withstand without compromising its integrity."@en ;
                                                       skos:prefLabel "Maximum Allowable Tensile"@en ,
                                                                      "Tração Máxima Permitida"@pt-br ;
-                                                      :hasAttributeScope :TypeLevelAttribute ;
-                                                      :hasTypedValue :floatValue ;
-                                                      :hasValueCardinality :multiValue .
+                                                      edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                                      edo:hasTypedValue edo:floatValue ;
+                                                      edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MaximumAllowableTensionTable_PulleyRadius
-:MaximumAllowableTensionTable_PulleyRadius rdf:type owl:Class ;
-                                           rdfs:subClassOf :CrushingMaximumAllowableTensionTableColumn ;
+edo:MaximumAllowableTensionTable_PulleyRadius rdf:type owl:Class ;
+                                           rdfs:subClassOf edo:CrushingMaximumAllowableTensionTableColumn ;
                                            dcterms:accessRights "PUBLIC" ;
                                            dcterms:identifier "MaximumAllowableTensionTable_PulleyRadius" ;
                                            skos:definition "The distance measured from the center of the pulley to the bottom of the \"V\" shape."@en ;
                                            skos:prefLabel "Pulley Radius"@en ,
                                                           "Raio da Polia"@pt-br ;
-                                           :hasAttributeScope :TypeLevelAttribute ;
-                                           :hasTypedValue :floatValue ;
-                                           :hasValueCardinality :multiValue .
+                                           edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                           edo:hasTypedValue edo:floatValue ;
+                                           edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MaximumAllowableTensionTable_PulleyVAngle
-:MaximumAllowableTensionTable_PulleyVAngle rdf:type owl:Class ;
-                                           rdfs:subClassOf :CrushingMaximumAllowableTensionTableColumn ;
+edo:MaximumAllowableTensionTable_PulleyVAngle rdf:type owl:Class ;
+                                           rdfs:subClassOf edo:CrushingMaximumAllowableTensionTableColumn ;
                                            dcterms:accessRights "PUBLIC" ;
                                            dcterms:identifier "MaximumAllowableTensionTable_PulleyVAngle" ;
                                            skos:definition "The angle formed by the opening of the \"V\" Groove in the pulley, measured in degrees."@en ;
                                            skos:prefLabel "Pulley V Groove Angle"@en ,
                                                           "Ângulo do Sulco em V da Polia"@pt-br ;
-                                           :hasAttributeScope :TypeLevelAttribute ;
-                                           :hasTypedValue :floatValue ;
-                                           :hasValueCardinality :multiValue .
+                                           edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                           edo:hasTypedValue edo:floatValue ;
+                                           edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MaximumAllowableTighteningTable_AxialLoad
-:MaximumAllowableTighteningTable_AxialLoad rdf:type owl:Class ;
-                                           rdfs:subClassOf :CrushingMaximumAllowableTighteningTableColumn ;
+edo:MaximumAllowableTighteningTable_AxialLoad rdf:type owl:Class ;
+                                           rdfs:subClassOf edo:CrushingMaximumAllowableTighteningTableColumn ;
                                            dcterms:accessRights "PUBLIC" ;
                                            dcterms:identifier "MaximumAllowableTighteningTable_AxialLoad" ;
                                            skos:definition "Represents the force applied along the longitudinal axis of a component or system. This property is important for evaluating the ability of the structure to resist stretching or compression, ensuring it maintains integrity under operational loads."@en ;
                                            skos:prefLabel "Axial Load"@en ,
                                                           "Tabela de Aperto Máximo Permitido - Carga Axial"@pt-br ;
-                                           :hasAttributeScope :TypeLevelAttribute ;
-                                           :hasTypedValue :floatValue ;
-                                           :hasValueCardinality :multiValue .
+                                           edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                           edo:hasTypedValue edo:floatValue ;
+                                           edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MaximumAllowableTighteningTable_TighteningPerTrack
-:MaximumAllowableTighteningTable_TighteningPerTrack rdf:type owl:Class ;
-                                                    rdfs:subClassOf :CrushingMaximumAllowableTighteningTableColumn ;
+edo:MaximumAllowableTighteningTable_TighteningPerTrack rdf:type owl:Class ;
+                                                    rdfs:subClassOf edo:CrushingMaximumAllowableTighteningTableColumn ;
                                                     dcterms:accessRights "PUBLIC" ;
                                                     dcterms:identifier "MaximumAllowableTighteningTable_TighteningPerTrack" ;
                                                     skos:definition "Indicates the amount of tightening applied per track during an operation. This property is important for ensuring consistent force distribution across multiple tracks, helping to maintain proper alignment and secure attachment during the tightening process."@en ;
                                                     skos:prefLabel "Tabela de Aperto Máximo Permitido - Aperto por Lagarta"@pt-br ,
                                                                    "Tightening Per Track"@en ;
-                                                    :hasAttributeScope :TypeLevelAttribute ;
-                                                    :hasTypedValue :floatValue ;
-                                                    :hasValueCardinality :multiValue .
+                                                    edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                                    edo:hasTypedValue edo:floatValue ;
+                                                    edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MaximumAmbientTemperature
-:MaximumAmbientTemperature rdf:type owl:Class ;
-                           rdfs:subClassOf :CrushingFrictionCoefficientTighteningAttribute ,
-                                           :CrushingMaximumAllowableTensionAttribute ,
-                                           :CrushingMaximumAllowableTighteningAttribute ;
+edo:MaximumAmbientTemperature rdf:type owl:Class ;
+                           rdfs:subClassOf edo:CrushingFrictionCoefficientTighteningAttribute ,
+                                           edo:CrushingMaximumAllowableTensionAttribute ,
+                                           edo:CrushingMaximumAllowableTighteningAttribute ;
                            dcterms:accessRights "PUBLIC" ;
                            dcterms:identifier "MaximumAmbientTemperature" ;
                            skos:definition "Represents the highest ambient temperature at which a component or material can operate effectively without risk of degradation or failure. This property is crucial for ensuring the material's performance and longevity under elevated temperature conditions."@en ;
                            skos:prefLabel "Maximum Ambient Temperature"@en ,
                                           "Temperatura ambiente máxima"@pt-br ;
-                           :hasAttributeScope :TypeLevelAttribute ;
-                           :hasTypedValue :floatValue ;
-                           :hasValueCardinality :singleValue .
+                           edo:hasAttributeScope edo:TypeLevelAttribute ;
+                           edo:hasTypedValue edo:floatValue ;
+                           edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MaximumTemperature
-:MaximumTemperature rdf:type owl:Class ;
-                    rdfs:subClassOf :DomainAttribute ;
+edo:MaximumTemperature rdf:type owl:Class ;
+                    rdfs:subClassOf edo:DomainAttribute ;
                     dcterms:accessRights "PUBLIC" ;
                     dcterms:identifier "MaximumTemperature" ;
                     skos:definition "Represents the highest temperature at which the structure or component can safely operate without compromising its integrity or performance. This value is critical for ensuring that materials and components maintain their mechanical properties and do not experience degradation, deformation, or failure under extreme thermal conditions."@en ;
                     skos:prefLabel "Maximum Temperature"@en ,
                                    "Temperatura Máxima"@pt-br ;
-                    :hasAttributeScope :InstanceLevelAttribute ;
-                    :hasTypedValue :floatValue ;
-                    :hasValueCardinality :singleValue .
+                    edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                    edo:hasTypedValue edo:floatValue ;
+                    edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MaximumThermalExchangeCoefficient
-:MaximumThermalExchangeCoefficient rdf:type owl:Class ;
-                                   rdfs:subClassOf :DomainAttribute ;
+edo:MaximumThermalExchangeCoefficient rdf:type owl:Class ;
+                                   rdfs:subClassOf edo:DomainAttribute ;
                                    dcterms:accessRights "PUBLIC" ;
                                    dcterms:identifier "MaximumThermalExchangeCoefficient" ;
                                    skos:definition "Indicates the maximum allowable value for the Thermal Exchange Coefficient (TEC), specifying the upper limit for heat transfer in the design. This value ensures that the flexible pipeline meets thermal performance requirements without exceeding the permissible heat transfer rate, which could affect its integrity and operational efficiency."@en ;
                                    skos:prefLabel "Coeficiente Máximo de Troca Térmica (TEC)"@pt-br ,
                                                   "Maximum Thermal Exchange Coefficient (TEC)"@en ;
-                                   :hasAttributeScope :InstanceLevelAttribute ;
-                                   :hasTypedValue :floatValue ;
-                                   :hasValueCardinality :singleValue .
+                                   edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                   edo:hasTypedValue edo:floatValue ;
+                                   edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MeasuredValue
-:MeasuredValue rdf:type owl:Class ;
-               rdfs:subClassOf :ValueOrigin ;
+edo:MeasuredValue rdf:type owl:Class ;
+               rdfs:subClassOf edo:ValueOrigin ;
                rdfs:comment "Obtained by direct measurement."@en ;
                rdfs:label "Measured"@en ,
                           "Medido"@pt-br ;
@@ -4037,131 +4036,131 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#MetallicLayerMaterialType
-:MetallicLayerMaterialType rdf:type owl:Class ;
-                           rdfs:subClassOf :DomainAttribute ;
+edo:MetallicLayerMaterialType rdf:type owl:Class ;
+                           rdfs:subClassOf edo:DomainAttribute ;
                            dcterms:accessRights "PUBLIC" ;
                            dcterms:identifier "MetallicLayerMaterialType" ;
                            skos:definition "Type of material from which an object is made, allowing for precise documentation and categorisation."@en ;
                            skos:prefLabel "Metallic Layer Material Type"@en ,
                                           "Tipo de Material da Camada Metálica"@pt-br ;
-                           :hasAttributeScope :TypeLevelAttribute ;
-                           :hasTypedValue :stringValue ;
-                           :hasValueCardinality :singleValue .
+                           edo:hasAttributeScope edo:TypeLevelAttribute ;
+                           edo:hasTypedValue edo:stringValue ;
+                           edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MetallicLayerPitch
-:MetallicLayerPitch rdf:type owl:Class ;
-                    rdfs:subClassOf :DomainAttribute ;
+edo:MetallicLayerPitch rdf:type owl:Class ;
+                    rdfs:subClassOf edo:DomainAttribute ;
                     dcterms:accessRights "PUBLIC" ;
                     dcterms:identifier "MetallicLayerPitch" ;
                     skos:definition "Indicates the distance between adjacent metallic elements in the layer, typically arranged helicoidally. This value is critical for determining the mechanical properties of the metallic layer, such as its flexibility, strength, and performance under load."@en ;
                     skos:prefLabel "Metallic Layer Pitch"@en ,
                                    "Passo da Camada Metálica"@pt-br ;
-                    :hasAttributeScope :InstanceLevelAttribute ;
-                    :hasTypedValue :floatValue ;
-                    :hasValueCardinality :singleValue .
+                    edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                    edo:hasTypedValue edo:floatValue ;
+                    edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MetallicMaterial
-:MetallicMaterial rdf:type owl:Class ;
-                  rdfs:subClassOf :FlexibleStructureLayerMaterial ;
+edo:MetallicMaterial rdf:type owl:Class ;
+                  rdfs:subClassOf edo:FlexibleStructureLayerMaterial ;
                   dcterms:identifier "MetallicMaterial" ;
                   skos:definition "Material used in the fabrication of metallic layers in subsea flexible pipes, chosen for its strength, durability, and resistance to harsh environmental conditions. The Metallic Material provides structural reinforcement, enhances pressure resistance, and supports the pipe's overall integrity. Commonly used materials include stainless steel, carbon steel, or other corrosion-resistant alloys, which are selected based on their ability to withstand the operational demands of deepwater environments, such as high pressure, tension, and dynamic loading."@en ;
                   skos:prefLabel "Material Metálico"@pt-br ,
                                  "Metallic Material"@en ;
-                  :hasAttribute :FractureToughness ,
-                                :MetallicLayerMaterialType ,
-                                :UltimateTensileStress ;
-                  :ifc_equivalentClass "IfcMaterial" ;
-                  :ifc_objectType "MetallicMaterial" .
+                  edo:hasAttribute edo:FractureToughness ,
+                                edo:MetallicLayerMaterialType ,
+                                edo:UltimateTensileStress ;
+                  edo:ifc_equivalentClass "IfcMaterial" ;
+                  edo:ifc_objectType "MetallicMaterial" .
 
 
 ###  https://w3id.org/energy-domain/edo#MetallicStrandLength
-:MetallicStrandLength rdf:type owl:Class ;
-                      rdfs:subClassOf :DomainAttribute ;
+edo:MetallicStrandLength rdf:type owl:Class ;
+                      rdfs:subClassOf edo:DomainAttribute ;
                       dcterms:accessRights "PUBLIC" ;
                       dcterms:identifier "MetallicStrandLength" ;
                       skos:definition "The total length of the metallic strand used in the anode to endfittings connection"@en ;
                       skos:prefLabel "Comprimento da Cordoalha Metálica"@pt-br ,
                                      "Metallic Strand Length"@en ;
-                      :hasAttributeScope :TypeLevelAttribute ;
-                      :hasTypedValue :floatValue ;
-                      :hasValueCardinality :singleValue .
+                      edo:hasAttributeScope edo:TypeLevelAttribute ;
+                      edo:hasTypedValue edo:floatValue ;
+                      edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MetallicStrandSet
-:MetallicStrandSet rdf:type owl:Class ;
-                   rdfs:subClassOf :PhysicalConnection ;
+edo:MetallicStrandSet rdf:type owl:Class ;
+                   rdfs:subClassOf edo:PhysicalConnection ;
                    dcterms:identifier "MetallicStrandSet" ;
                    skos:definition "Galvanic connection cables set providing reliable electrical link between anodes and metal infrastructure for effective corrosion mitigation."@en ;
                    skos:prefLabel "Conjunto de Cordoalhas de Continuidade"@pt-br ,
                                   "Metallic Strand Set"@en ;
-                   :hasAttribute :StrandsTable_SpareQuantity ,
-                                 :StrandsTable_StrandsLength ,
-                                 :StrandsTable_StrandsQuantity ;
-                   :ifc_equivalentClass "IfcCableSegment" ;
-                   :ifc_objectType "MetallicStrandSet" ;
-                   :ifc_predefinedType "USERDEFINED" .
+                   edo:hasAttribute edo:StrandsTable_SpareQuantity ,
+                                 edo:StrandsTable_StrandsLength ,
+                                 edo:StrandsTable_StrandsQuantity ;
+                   edo:ifc_equivalentClass "IfcCableSegment" ;
+                   edo:ifc_objectType "MetallicStrandSet" ;
+                   edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#MetallicStrandSpareQuantity
-:MetallicStrandSpareQuantity rdf:type owl:Class ;
-                             rdfs:subClassOf :DomainAttribute ;
+edo:MetallicStrandSpareQuantity rdf:type owl:Class ;
+                             rdfs:subClassOf edo:DomainAttribute ;
                              dcterms:accessRights "PUBLIC" ;
                              dcterms:identifier "MetallicStrandSpareQuantity" ;
                              skos:definition "The additional quantity of metallic strands provided as spare material for contingency or repair purposes."@en ;
                              skos:prefLabel "Metallic Strand Spare Quantity"@en ,
                                             "Quantidade de Cordoalhas Metálicas Sobressalentes"@pt-br ;
-                             :hasAttributeScope :TypeLevelAttribute ;
-                             :hasTypedValue :intValue ;
-                             :hasValueCardinality :singleValue .
+                             edo:hasAttributeScope edo:TypeLevelAttribute ;
+                             edo:hasTypedValue edo:intValue ;
+                             edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MetallicTubing
-:MetallicTubing rdf:type owl:Class ;
-                rdfs:subClassOf :Tubing ;
+edo:MetallicTubing rdf:type owl:Class ;
+                rdfs:subClassOf edo:Tubing ;
                 dcterms:identifier "MetallicTubing" ;
-                :ifc_equivalentClass "IfcPipeSegment" ;
-                :ifc_objectType "MetallicTubing" ;
-                :ifc_predefinedType "USERDEFINED" .
+                edo:ifc_equivalentClass "IfcPipeSegment" ;
+                edo:ifc_objectType "MetallicTubing" ;
+                edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#MetricBoltSet
-:MetricBoltSet rdf:type owl:Class ;
-               rdfs:subClassOf :BoltSet ;
+edo:MetricBoltSet rdf:type owl:Class ;
+               rdfs:subClassOf edo:BoltSet ;
                dcterms:identifier "MetricBoltSet" ;
                skos:definition "A set of bolts and accompanying hardware sized using the metric measurement system, commonly used in subsea applications for international compatibility and standardization."@en ;
                skos:prefLabel "Conjunto de Parafusos Métrico"@pt-br ,
                               "Metric Bolt Set"@en ;
-               :hasAttribute :NominalDiameter ,
-                             :PitchToleranceClass ,
-                             :ThreadPitch ,
-                             :ThreadStandard ;
-               :ifc_equivalentClass "IfcMechanicalFastener" ;
-               :ifc_objectType "MetricBoltSet" ;
-               :ifc_predefinedType "USERDEFINED" .
+               edo:hasAttribute edo:NominalDiameter ,
+                             edo:PitchToleranceClass ,
+                             edo:ThreadPitch ,
+                             edo:ThreadStandard ;
+               edo:ifc_equivalentClass "IfcMechanicalFastener" ;
+               edo:ifc_objectType "MetricBoltSet" ;
+               edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#MetricStudSet
-:MetricStudSet rdf:type owl:Class ;
-               rdfs:subClassOf :StudSet ;
+edo:MetricStudSet rdf:type owl:Class ;
+               rdfs:subClassOf edo:StudSet ;
                dcterms:identifier "MetricStudSet" ;
                skos:altLabel "Metric Stud"@en ,
                              "Metric Threaded Rod"@en ;
                skos:definition "Metric studs are crucial fastening components for subsea oil and gas components, designed specifically to secure equipment parts. Each set includes bolts, nuts, and washers in metric sizing, made from high-strength, corrosion-resistant materials to withstand the demanding subsea environment. These components offer dependable fastening, ensuring structural integrity and leak prevention in end fittings. Metric stud sets are engineered to endure high pressure and extreme temperatures, making them essential for the safety and durability of subsea interconnections."@en ;
                skos:prefLabel "Conjunto de Estojos Métrico"@pt-br ,
                               "Metric Stud Set"@en ;
-               :hasAttribute :PitchToleranceClass ,
-                             :ThreadPitch ,
-                             :ThreadStandard ;
-               :ifc_equivalentClass "IfcMechanicalFastener" ;
-               :ifc_objectType "MetricStudSet" ;
-               :ifc_predefinedType "USERDEFINED" .
+               edo:hasAttribute edo:PitchToleranceClass ,
+                             edo:ThreadPitch ,
+                             edo:ThreadStandard ;
+               edo:ifc_equivalentClass "IfcMechanicalFastener" ;
+               edo:ifc_objectType "MetricStudSet" ;
+               edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#Midstream
-:Midstream rdf:type owl:Class ;
-           rdfs:subClassOf :OilAndGas ;
+edo:Midstream rdf:type owl:Class ;
+           rdfs:subClassOf edo:OilAndGas ;
            rdfs:label "Midstream"@en ,
                       "Midstream"@pt-br ;
            skos:definition "Oil & Gas sector covering transportation, storage, and wholesale marketing of crude or refined petroleum products."@en ,
@@ -4169,47 +4168,47 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#MinimumBendingRadiusForStorage
-:MinimumBendingRadiusForStorage rdf:type owl:Class ;
-                                rdfs:subClassOf :DomainAttribute ;
+edo:MinimumBendingRadiusForStorage rdf:type owl:Class ;
+                                rdfs:subClassOf edo:DomainAttribute ;
                                 dcterms:accessRights "PUBLIC" ;
                                 dcterms:identifier "MinimumBendingRadiusForStorage" ;
                                 skos:definition "Represents the smallest radius to which a component can be bent during storage without causing damage or affecting its performance. This property is important for ensuring that the component maintains its integrity while in storage, preventing deformation or weakening."@en ;
                                 skos:prefLabel "Minimum Bending Radius For Storage"@en ,
                                                "Raio Mínimo de Curvatura para Armazenamento"@pt-br ;
-                                :hasAttributeScope :TypeLevelAttribute ;
-                                :hasTypedValue :floatValue ;
-                                :hasValueCardinality :singleValue .
+                                edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                edo:hasTypedValue edo:floatValue ;
+                                edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MinimumTemperature
-:MinimumTemperature rdf:type owl:Class ;
-                    rdfs:subClassOf :DomainAttribute ;
+edo:MinimumTemperature rdf:type owl:Class ;
+                    rdfs:subClassOf edo:DomainAttribute ;
                     dcterms:accessRights "PUBLIC" ;
                     dcterms:identifier "MinimumTemperature" ;
                     skos:definition "Represents the lowest temperature at which the structure or component can safely operate without experiencing performance degradation or failure. This value is important for ensuring that the materials maintain their properties and structural integrity when exposed to extremely low temperatures"@en ;
                     skos:prefLabel "Minimum Temperature"@en ,
                                    "Temperatura Mínima"@pt-br ;
-                    :hasAttributeScope :TypeLevelAttribute ;
-                    :hasTypedValue :floatValue ;
-                    :hasValueCardinality :singleValue .
+                    edo:hasAttributeScope edo:TypeLevelAttribute ;
+                    edo:hasTypedValue edo:floatValue ;
+                    edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MinimumThermalExchangeCoefficient
-:MinimumThermalExchangeCoefficient rdf:type owl:Class ;
-                                   rdfs:subClassOf :DomainAttribute ;
+edo:MinimumThermalExchangeCoefficient rdf:type owl:Class ;
+                                   rdfs:subClassOf edo:DomainAttribute ;
                                    dcterms:accessRights "PUBLIC" ;
                                    dcterms:identifier "MinimumThermalExchangeCoefficient" ;
                                    skos:definition "Indicates the minimum allowable value for the Thermal Exchange Coefficient (TEC), specifying the lower limit for heat transfer in the design. This value ensures that the flexible pipeline maintains sufficient heat transfer capability to meet operational performance requirements."@en ;
                                    skos:prefLabel "Coeficiente Mínimo de Troca Térmica (TEC)"@pt-br ,
                                                   "Minimum Thermal Exchange Coefficient (TEC)"@en ;
-                                   :hasAttributeScope :InstanceLevelAttribute ;
-                                   :hasTypedValue :floatValue ;
-                                   :hasValueCardinality :singleValue .
+                                   edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                   edo:hasTypedValue edo:floatValue ;
+                                   edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#ModelLocationPoint
-:ModelLocationPoint rdf:type owl:Class ;
-                    rdfs:subClassOf :DomainElement ;
+edo:ModelLocationPoint rdf:type owl:Class ;
+                    rdfs:subClassOf edo:DomainElement ;
                     dcterms:identifier "ModelLocationPoint" ;
                     skos:definition "A specific reference point or coordinate used to define the precise location of equipment, infrastructure, or components within a 3D model."@en ;
                     skos:prefLabel "Model Location Point"@en ,
@@ -4217,21 +4216,21 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#ModulusOfElasticity
-:ModulusOfElasticity rdf:type owl:Class ;
-                     rdfs:subClassOf :DomainAttribute ;
+edo:ModulusOfElasticity rdf:type owl:Class ;
+                     rdfs:subClassOf edo:DomainAttribute ;
                      dcterms:accessRights "PUBLIC" ;
                      dcterms:identifier "ModulusOfElasticity" ;
                      skos:definition "The modulus of elasticity represents the material's ability to resist deformation under stress. It quantifies the ratio of stress to strain within the elastic range of the material. This property is crucial for understanding how the material will behave under various loads and conditions."@en ;
                      skos:prefLabel "Modulus Of Elasticity"@en ,
                                     "Módulo de elasticidade"@pt-br ;
-                     :hasAttributeScope :InstanceLevelAttribute ;
-                     :hasTypedValue :floatValue ;
-                     :hasValueCardinality :singleValue .
+                     edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                     edo:hasTypedValue edo:floatValue ;
+                     edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#MooringAccessory
-:MooringAccessory rdf:type owl:Class ;
-                  rdfs:subClassOf :HardwareItem ;
+edo:MooringAccessory rdf:type owl:Class ;
+                  rdfs:subClassOf edo:HardwareItem ;
                   dcterms:identifier "MooringAccessory" ;
                   skos:definition "A Mooring Accessory includes components like anchors, chains, and connectors used to secure offshore platforms or vessels to the seabed, ensuring stability and safety in harsh marine conditions."@en ;
                   skos:prefLabel "Acessório de Amarração"@pt-br ,
@@ -4239,62 +4238,62 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#NominalDiameter
-:NominalDiameter rdf:type owl:Class ;
-                 rdfs:subClassOf :DomainAttribute ;
+edo:NominalDiameter rdf:type owl:Class ;
+                 rdfs:subClassOf edo:DomainAttribute ;
                  dcterms:accessRights "PUBLIC" ;
                  dcterms:identifier "NominalDiameter" ;
                  skos:definition "The standard diameter of the component or pipe, typically used for classification and specification purposes."@en ;
                  skos:prefLabel "Diâmetro Nominal"@pt-br ,
                                 "Nominal Diameter"@en ;
-                 :hasAttributeScope :InstanceLevelAttribute ;
-                 :hasTypedValue :stringValue ;
-                 :hasValueCardinality :singleValue .
+                 edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                 edo:hasTypedValue edo:stringValue ;
+                 edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#NominalFloatDensity
-:NominalFloatDensity rdf:type owl:Class ;
-                     rdfs:subClassOf :DomainAttribute ;
+edo:NominalFloatDensity rdf:type owl:Class ;
+                     rdfs:subClassOf edo:DomainAttribute ;
                      dcterms:accessRights "PUBLIC" ;
                      dcterms:identifier "NominalFloatDensity" ;
                      skos:definition "A densidade ideal do flutuador antes de qualquer absorção de água ou degradação. Usada para calcular a flutuabilidade inicial máxima, idealmente no ponto de fabricação."@pt-br ,
                                      "The ideal density of the float material before any water absorption or degradation occurs. This is used to calculate the float's maximum buoyancy at the beginning of its use."@en ;
                      skos:prefLabel "Densidade Nominal do Flutuador"@pt-br ,
                                     "Nominal Float Density"@en ;
-                     :hasAttributeScope :TypeLevelAttribute ;
-                     :hasTypedValue :floatValue ;
-                     :hasValueCardinality :singleValue .
+                     edo:hasAttributeScope edo:TypeLevelAttribute ;
+                     edo:hasTypedValue edo:floatValue ;
+                     edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#NominalFloatVolume
-:NominalFloatVolume rdf:type owl:Class ;
-                    rdfs:subClassOf :DomainAttribute ;
+edo:NominalFloatVolume rdf:type owl:Class ;
+                    rdfs:subClassOf edo:DomainAttribute ;
                     dcterms:accessRights "PUBLIC" ;
                     dcterms:identifier "NominalFloatVolume" ;
                     skos:definition "O volume ideal, ou \"de fábrica\", sem considerar a absorção de água ou deformações. É usado para calcular a flutuabilidade máxima possível, antes de qualquer degradação."@pt-br ,
                                     "The ideal or factory-specified volume of the float before any external effects like water absorption or deformation occur. This value is used to calculate the maximum buoyancy under perfect conditions."@en ;
                     skos:prefLabel "Nominal Float Volume"@en ,
                                    "Volume Nominal do Flutuador"@pt-br ;
-                    :hasAttributeScope :TypeLevelAttribute ;
-                    :hasTypedValue :floatValue ;
-                    :hasValueCardinality :singleValue .
+                    edo:hasAttributeScope edo:TypeLevelAttribute ;
+                    edo:hasTypedValue edo:floatValue ;
+                    edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#NominalLength
-:NominalLength rdf:type owl:Class ;
-               rdfs:subClassOf :DomainAttribute ;
+edo:NominalLength rdf:type owl:Class ;
+               rdfs:subClassOf edo:DomainAttribute ;
                dcterms:accessRights "PUBLIC" ;
                dcterms:identifier "NominalLength" ;
                skos:definition "Nominal length refers to the length of an object as designed, typically used as a reference value. It may not represent the exact physical measurement but serves as the standard or intended length for manufacturing, design, or specification purposes."@en ;
                skos:prefLabel "Comprimento Nominal"@pt-br ,
                               "Nominal Length"@en ;
-               :hasAttributeScope :InstanceLevelAttribute ;
-               :hasTypedValue :floatValue ;
-               :hasValueCardinality :singleValue .
+               edo:hasAttributeScope edo:InstanceLevelAttribute ;
+               edo:hasTypedValue edo:floatValue ;
+               edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#Nuclear
-:Nuclear rdf:type owl:Class ;
-         rdfs:subClassOf :Domain ;
+edo:Nuclear rdf:type owl:Class ;
+         rdfs:subClassOf edo:Domain ;
          rdfs:label "Energia Nuclear"@pt-br ,
                     "Nuclear Energy"@en ;
          skos:definition "Domínio industrial que abrange a geração de energia a partir de reações nucleares, incluindo fissão e fusão."@pt-br ,
@@ -4302,8 +4301,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#NuclearFuelCycle
-:NuclearFuelCycle rdf:type owl:Class ;
-                  rdfs:subClassOf :Nuclear ;
+edo:NuclearFuelCycle rdf:type owl:Class ;
+                  rdfs:subClassOf edo:Nuclear ;
                   rdfs:label "Ciclo do Combustível Nuclear"@pt-br ,
                              "Nuclear Fuel Cycle"@en ;
                   skos:definition "Processes involved in mining, processing, enrichment, and disposal of nuclear fuel."@en ,
@@ -4311,8 +4310,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#NuclearPowerGeneration
-:NuclearPowerGeneration rdf:type owl:Class ;
-                        rdfs:subClassOf :Nuclear ;
+edo:NuclearPowerGeneration rdf:type owl:Class ;
+                        rdfs:subClassOf edo:Nuclear ;
                         rdfs:label "Geração de Energia Nuclear"@pt-br ,
                                    "Nuclear Power Generation"@en ;
                         skos:definition "Operation and maintenance of nuclear power plants for electricity production."@en ,
@@ -4320,118 +4319,118 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#NumberOfChokeValves
-:NumberOfChokeValves rdf:type owl:Class ;
-                     rdfs:subClassOf :DomainAttribute ;
+edo:NumberOfChokeValves rdf:type owl:Class ;
+                     rdfs:subClassOf edo:DomainAttribute ;
                      dcterms:accessRights "PUBLIC" ;
                      dcterms:identifier "NumberOfChokeValves" ;
                      skos:definition "Number of process choke valves"@en ,
                                      "Número de válvulas choke"@pt-br ;
                      skos:prefLabel "Number Of Choke Valves"@en ,
                                     "Número de válvulas de estrangulamento"@pt-br ;
-                     :hasAttributeScope :TypeLevelAttribute ;
-                     :hasTypedValue :intValue ;
-                     :hasValueCardinality :singleValue .
+                     edo:hasAttributeScope edo:TypeLevelAttribute ;
+                     edo:hasTypedValue edo:intValue ;
+                     edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#NumberOfRemoteProcessIsolationValves
-:NumberOfRemoteProcessIsolationValves rdf:type owl:Class ;
-                                      rdfs:subClassOf :DomainAttribute ;
+edo:NumberOfRemoteProcessIsolationValves rdf:type owl:Class ;
+                                      rdfs:subClassOf edo:DomainAttribute ;
                                       dcterms:accessRights "PUBLIC" ;
                                       dcterms:identifier "NumberOfRemoteProcessIsolationValves" ;
                                       skos:definition "Number of remotely-actuated process isolation valves"@en ,
                                                       "Número de válvulas de isolamento de processo com atuação remota"@pt-br ;
                                       skos:prefLabel "Number Of Remote Process Isolation Valves"@en ,
                                                      "Número de válvulas de isolamento de processo remoto"@pt-br ;
-                                      :hasAttributeScope :TypeLevelAttribute ;
-                                      :hasTypedValue :intValue ;
-                                      :hasValueCardinality :singleValue .
+                                      edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                      edo:hasTypedValue edo:intValue ;
+                                      edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#OffLeakPLevMaxPress
-:OffLeakPLevMaxPress rdf:type owl:Class ;
-                     rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:OffLeakPLevMaxPress rdf:type owl:Class ;
+                     rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
                      dcterms:accessRights "PUBLIC" ;
                      dcterms:identifier "OffLeakPLevMaxPress" ;
                      skos:definition "Condições de teste dos tramos para Pressão - Máxima - Teste de vazamento hidrostático offshore (no nível da plataforma)"@pt-br ,
                                      "The maximum pressure applied during the Offshore Leak Test (at platform level), ensuring no leaks occur under extreme pressure."@en ;
                      skos:prefLabel "Offshore Leak Test At Platform Level Maximum Pressure"@en ,
                                     "Teste de Vazamento Offshore na Pressão Máxima no Nível da Plataforma"@pt-br ;
-                     :hasAttributeScope :InstanceLevelAttribute ;
-                     :hasTypedValue :floatValue ;
-                     :hasValueCardinality :singleValue .
+                     edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                     edo:hasTypedValue edo:floatValue ;
+                     edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#OffLeakPLevMaxPressValRef
-:OffLeakPLevMaxPressValRef rdf:type owl:Class ;
-                           rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:OffLeakPLevMaxPressValRef rdf:type owl:Class ;
+                           rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
                            dcterms:accessRights "PUBLIC" ;
                            dcterms:identifier "OffLeakPLevMaxPressValRef" ;
                            skos:definition "Comentários Condições de teste dos tramos para - Máximo - Teste de vazamento hidrostático offshore (no nível da plataforma)"@pt-br ,
                                            "Specifies the reference pressure used to determine the Offshore Leak Test maximum pressure value."@en ;
                            skos:prefLabel "Offshore Leak Test At Platform Level Maximum Pressure Value Reference"@en ,
                                           "Referência de Valor de Pressão Máxima para Teste de Vazamento Offshore no Nível da Plataforma"@pt-br ;
-                           :hasAttributeScope :InstanceLevelAttribute ;
-                           :hasTypedValue :stringValue ;
-                           :hasValueCardinality :singleValue .
+                           edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                           edo:hasTypedValue edo:stringValue ;
+                           edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#OffLeakPLevMaxPressValRefMult
-:OffLeakPLevMaxPressValRefMult rdf:type owl:Class ;
-                               rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:OffLeakPLevMaxPressValRefMult rdf:type owl:Class ;
+                               rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
                                dcterms:accessRights "PUBLIC" ;
                                dcterms:identifier "OffLeakPLevMaxPressValRefMult" ;
                                skos:definition "The multiplier applied to the reference pressure to determine the Offshore Leak Test maximum pressure value."@en ;
                                skos:prefLabel "Multiplicador de Referência de Valor de Pressão Máxima para Teste de Vazamento Offshore no Nível da Plataforma"@pt-br ,
                                               "Offshore Leak Test At Platform Level Maximum Pressure Value Reference Multiplier"@en ;
-                               :hasAttributeScope :InstanceLevelAttribute ;
-                               :hasTypedValue :floatValue ;
-                               :hasValueCardinality :singleValue .
+                               edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                               edo:hasTypedValue edo:floatValue ;
+                               edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#OffLeakPLevNomPress
-:OffLeakPLevNomPress rdf:type owl:Class ;
-                     rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:OffLeakPLevNomPress rdf:type owl:Class ;
+                     rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
                      dcterms:accessRights "PUBLIC" ;
                      dcterms:identifier "OffLeakPLevNomPress" ;
                      skos:definition "Condições de teste dos tramos para Pressão - Nominal - Teste de vazamento hidrostático offshore (no nível da plataforma)"@pt-br ,
                                      "The nominal pressure applied during the Offshore Leak Test (at platform level), simulating typical operating conditions to assess for leaks."@en ;
                      skos:prefLabel "Offshore Leak Test At Platform Level Nominal Pressure"@en ,
                                     "Pressão Nominal para Teste de Vazamento Offshore no Nível da Plataforma"@pt-br ;
-                     :hasAttributeScope :InstanceLevelAttribute ;
-                     :hasTypedValue :floatValue ;
-                     :hasValueCardinality :singleValue .
+                     edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                     edo:hasTypedValue edo:floatValue ;
+                     edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#OffLeakPLevNomPressValRef
-:OffLeakPLevNomPressValRef rdf:type owl:Class ;
-                           rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:OffLeakPLevNomPressValRef rdf:type owl:Class ;
+                           rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
                            dcterms:accessRights "PUBLIC" ;
                            dcterms:identifier "OffLeakPLevNomPressValRef" ;
                            skos:definition "Comentários Condições de teste dos tramos para - Nominal - Teste de vazamento hidrostático offshore (no nível da plataforma)"@pt-br ,
                                            "Specifies the reference pressure used to determine the Offshore Leak Test nominal pressure value."@en ;
                            skos:prefLabel "Offshore Leak Test At Platform Level Nominal Pressure Value Reference"@en ,
                                           "Referência de Valor de Pressão Nominal para Teste de Vazamento Offshore no Nível da Plataforma"@pt-br ;
-                           :hasAttributeScope :InstanceLevelAttribute ;
-                           :hasTypedValue :stringValue ;
-                           :hasValueCardinality :singleValue .
+                           edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                           edo:hasTypedValue edo:stringValue ;
+                           edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#OffLeakPLevNomPressValRefMult
-:OffLeakPLevNomPressValRefMult rdf:type owl:Class ;
-                               rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:OffLeakPLevNomPressValRefMult rdf:type owl:Class ;
+                               rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
                                dcterms:accessRights "PUBLIC" ;
                                dcterms:identifier "OffLeakPLevNomPressValRefMult" ;
                                skos:definition "The multiplier applied to the reference pressure to determine the Offshore Leak Test nominal pressure value."@en ;
                                skos:prefLabel "Multiplicador de Referência de Valor de Pressão Nominal para Teste de Vazamento Offshore no Nível da Plataforma"@pt-br ,
                                               "Offshore Leak Test At Platform Level Nominal Pressure Value Reference Multiplier"@en ;
-                               :hasAttributeScope :InstanceLevelAttribute ;
-                               :hasTypedValue :floatValue ;
-                               :hasValueCardinality :singleValue .
+                               edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                               edo:hasTypedValue edo:floatValue ;
+                               edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#Offshore
-:Offshore rdf:type owl:Class ;
-          rdfs:subClassOf :LocationType ;
+edo:Offshore rdf:type owl:Class ;
+          rdfs:subClassOf edo:LocationType ;
           rdfs:label "Offshore"@en ,
                      "Offshore"@pt-br ;
           skos:definition "Atividades industriais realizadas no mar, tipicamente para produção de petróleo & gás ou energia eólica."@pt-br ,
@@ -4439,8 +4438,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#OilAndGas
-:OilAndGas rdf:type owl:Class ;
-           rdfs:subClassOf :Domain ;
+edo:OilAndGas rdf:type owl:Class ;
+           rdfs:subClassOf edo:Domain ;
            rdfs:label "Oil & Gas"@en ,
                       "Petróleo & Gás"@pt-br ;
            skos:definition "Domínio industrial que abrange todas as atividades relacionadas à exploração, produção, refino e distribuição de petróleo e gás."@pt-br ,
@@ -4448,8 +4447,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#Onshore
-:Onshore rdf:type owl:Class ;
-         rdfs:subClassOf :LocationType ;
+edo:Onshore rdf:type owl:Class ;
+         rdfs:subClassOf edo:LocationType ;
          rdfs:label "Onshore"@en ,
                     "Onshore"@pt-br ;
          skos:definition "Atividades industriais realizadas em terra."@pt-br ,
@@ -4457,14 +4456,14 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#OpenReceptacle
-:OpenReceptacle rdf:type owl:Class ;
-                rdfs:subClassOf :RiserSupport ;
+edo:OpenReceptacle rdf:type owl:Class ;
+                rdfs:subClassOf edo:RiserSupport ;
                 dcterms:identifier "OpenReceptacle" .
 
 
 ###  https://w3id.org/energy-domain/edo#Operation
-:Operation rdf:type owl:Class ;
-           rdfs:subClassOf :LifecyclePhase ;
+edo:Operation rdf:type owl:Class ;
+           rdfs:subClassOf edo:LifecyclePhase ;
            rdfs:label "Operation"@en ,
                       "Operação"@pt-br ;
            skos:definition "Normal use of the asset for its intended purpose, including monitoring and control."@en ,
@@ -4472,61 +4471,61 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#OpticalFiberCable
-:OpticalFiberCable rdf:type owl:Class ;
-                   rdfs:subClassOf :FunctionLine ;
+edo:OpticalFiberCable rdf:type owl:Class ;
+                   rdfs:subClassOf edo:FunctionLine ;
                    dcterms:identifier "OpticalFiberCable" ;
-                   :ifc_equivalentClass "IfcCableSegment" ;
-                   :ifc_objectType "OpticalFiberCable" ;
-                   :ifc_predefinedType "USERDEFINED" .
+                   edo:ifc_equivalentClass "IfcCableSegment" ;
+                   edo:ifc_objectType "OpticalFiberCable" ;
+                   edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#OuterDiameter
-:OuterDiameter rdf:type owl:Class ;
-               rdfs:subClassOf :DomainAttribute ;
+edo:OuterDiameter rdf:type owl:Class ;
+               rdfs:subClassOf edo:DomainAttribute ;
                dcterms:accessRights "PUBLIC" ;
                dcterms:identifier "OuterDiameter" ;
                skos:definition "Represents the external diameter of a component, typically measured from one outer edge to the opposite outer edge. This property is important for ensuring proper fit, compatibility, and performance within a system or assembly."@en ;
                skos:prefLabel "Diâmetro externo"@pt-br ,
                               "Outer Diameter"@en ;
-               :hasAttributeScope :TypeLevelAttribute ;
-               :hasTypedValue :floatValue ;
-               :hasValueCardinality :singleValue .
+               edo:hasAttributeScope edo:TypeLevelAttribute ;
+               edo:hasTypedValue edo:floatValue ;
+               edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#OutsideTemperature
-:OutsideTemperature rdf:type owl:Class ;
-                    rdfs:subClassOf :BendingStiffnessAttribute ;
+edo:OutsideTemperature rdf:type owl:Class ;
+                    rdfs:subClassOf edo:BendingStiffnessAttribute ;
                     dcterms:accessRights "PUBLIC" ;
                     dcterms:identifier "OutsideTemperature" ;
                     skos:definition "Represents the external temperature surrounding a component or system. This property is important for assessing the thermal conditions that the component is exposed to, ensuring it operates within safe temperature limits."@en ;
                     skos:prefLabel "Outside Temperature"@en ,
                                    "Temperatura Externa"@pt-br ;
-                    :hasAttributeScope :TypeLevelAttribute ;
-                    :hasTypedValue :floatValue ;
-                    :hasValueCardinality :singleValue .
+                    edo:hasAttributeScope edo:TypeLevelAttribute ;
+                    edo:hasTypedValue edo:floatValue ;
+                    edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#OverrideTool
-:OverrideTool rdf:type owl:Class ;
-              rdfs:subClassOf :ROVTool ;
+edo:OverrideTool rdf:type owl:Class ;
+              rdfs:subClassOf edo:ROVTool ;
               dcterms:identifier "OverrideTool" .
 
 
 ###  https://w3id.org/energy-domain/edo#PLEM
-:PLEM rdf:type owl:Class ;
-      rdfs:subClassOf :Manifold ;
+edo:PLEM rdf:type owl:Class ;
+      rdfs:subClassOf edo:Manifold ;
       dcterms:identifier "PLEM" .
 
 
 ###  https://w3id.org/energy-domain/edo#PLET
-:PLET rdf:type owl:Class ;
-      rdfs:subClassOf :FlowControlEquipment ;
+edo:PLET rdf:type owl:Class ;
+      rdfs:subClassOf edo:FlowControlEquipment ;
       dcterms:identifier "PLET" .
 
 
 ###  https://w3id.org/energy-domain/edo#PackageEquipmentEngineering
-:PackageEquipmentEngineering rdf:type owl:Class ;
-                             rdfs:subClassOf :EquipmentEngineering ;
+edo:PackageEquipmentEngineering rdf:type owl:Class ;
+                             rdfs:subClassOf edo:EquipmentEngineering ;
                              rdfs:label "Engenharia de Equipamentos Modulares"@pt-br ,
                                         "Package Equipment Engineering"@en ;
                              skos:definition "Engenharia de sistemas de equipamentos modulares ou montados em skids."@pt-br ,
@@ -4534,21 +4533,21 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#PartNumber
-:PartNumber rdf:type owl:Class ;
-            rdfs:subClassOf :DomainAttribute ;
+edo:PartNumber rdf:type owl:Class ;
+            rdfs:subClassOf edo:DomainAttribute ;
             dcterms:accessRights "PUBLIC" ;
             dcterms:identifier "PartNumber" ;
             skos:definition "The Part Number is a unique identifier assigned to each type of element, ensuring consistency and ease of reference. This identifier helps in categorizing, ordering, and tracking the accessory within the system. When the drawing code is used consistently across all projects for a specific type of accessory, it can also serve as the Part Number, facilitating uniformity in documentation and usage."@en ;
             skos:prefLabel "Número da peça do acessório"@pt-br ,
                            "Part Number"@en ;
-            :hasAttributeScope :TypeLevelAttribute ;
-            :hasTypedValue :stringValue ;
-            :hasValueCardinality :singleValue .
+            edo:hasAttributeScope edo:TypeLevelAttribute ;
+            edo:hasTypedValue edo:stringValue ;
+            edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#PerformanceAttribute
-:PerformanceAttribute rdf:type owl:Class ;
-                      rdfs:subClassOf :AttributeDomainCategory ;
+edo:PerformanceAttribute rdf:type owl:Class ;
+                      rdfs:subClassOf edo:AttributeDomainCategory ;
                       rdfs:comment "Represents performance or capacity values such as pressure rating or power."@en ;
                       rdfs:label "Atributo de Desempenho"@pt-br ,
                                  "Performance Attribute"@en ;
@@ -4557,74 +4556,74 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#PermeabilityTableAttribute
-:PermeabilityTableAttribute rdf:type owl:Class ;
-                            rdfs:subClassOf :DomainAttribute ;
+edo:PermeabilityTableAttribute rdf:type owl:Class ;
+                            rdfs:subClassOf edo:DomainAttribute ;
                             dcterms:accessRights "PUBLIC" ;
                             dcterms:identifier "PermeabilityTable" ;
                             skos:definition "Permeabilidade (Específica para Materiais Poliméricos)"@pt-br ,
                                             "Provides data on the permeability of various substances through materials, helping to assess the rate at which fluids or gases can pass through the structure. This information is crucial for evaluating material performance, ensuring compatibility, and predicting long-term behavior under operational conditions."@en ;
                             skos:prefLabel "Permeability Table"@en ,
                                            "Tabela de Permeabilidade"@pt-br ;
-                            :hasAttributeScope :TypeLevelAttribute .
+                            edo:hasAttributeScope edo:TypeLevelAttribute .
 
 
 ###  https://w3id.org/energy-domain/edo#PermeabilityTable_MoleculeIdentifier
-:PermeabilityTable_MoleculeIdentifier rdf:type owl:Class ;
-                                      rdfs:subClassOf :PermeabilityTableAttribute ;
+edo:PermeabilityTable_MoleculeIdentifier rdf:type owl:Class ;
+                                      rdfs:subClassOf edo:PermeabilityTableAttribute ;
                                       dcterms:accessRights "PUBLIC" ;
                                       dcterms:identifier "PermeabilityTable_MoleculeIdentifier" ;
                                       skos:definition "Specifies the type of molecule. This property identifies the particular molecule involved, which is crucial for understanding the material's interaction with or response to different chemical substances."@en ,
                                                       "tipo de molécula (co2, h2s, ch4, h2o,…)"@pt-br ;
                                       skos:prefLabel "Identificador de Molécula"@pt-br ,
                                                      "Molecule Identifier"@en ;
-                                      :hasAttributeScope :TypeLevelAttribute ;
-                                      :hasTypedValue :stringValue ;
-                                      :hasValueCardinality :multiValue .
+                                      edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                      edo:hasTypedValue edo:stringValue ;
+                                      edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#PermeabilityTable_PermeabilityCoefficient
-:PermeabilityTable_PermeabilityCoefficient rdf:type owl:Class ;
-                                           rdfs:subClassOf :PermeabilityTableAttribute ;
+edo:PermeabilityTable_PermeabilityCoefficient rdf:type owl:Class ;
+                                           rdfs:subClassOf edo:PermeabilityTableAttribute ;
                                            dcterms:accessRights "PUBLIC" ;
                                            dcterms:identifier "PermeabilityTable_PermeabilityCoefficient" ;
                                            skos:definition "Represents the rate at which a substance, such as a gas or liquid, can pass through a material. This property is crucial for understanding the material's resistance to permeation, helping to assess its suitability for containing or isolating specific substances."@en ;
                                            skos:prefLabel "Coeficiente de Permeabilidade"@pt-br ,
                                                           "Permeability Coefficient"@en ;
-                                           :hasAttributeScope :TypeLevelAttribute ;
-                                           :hasTypedValue :floatValue ;
-                                           :hasValueCardinality :multiValue .
+                                           edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                           edo:hasTypedValue edo:floatValue ;
+                                           edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#PermeabilityTable_PolymerState
-:PermeabilityTable_PolymerState rdf:type owl:Class ;
-                                rdfs:subClassOf :PermeabilityTableAttribute ;
+edo:PermeabilityTable_PolymerState rdf:type owl:Class ;
+                                rdfs:subClassOf edo:PermeabilityTableAttribute ;
                                 dcterms:accessRights "PUBLIC" ;
                                 dcterms:identifier "PermeabilityTable_PolymerState" ;
                                 skos:definition "(plastificado, não plastificado,…)"@pt-br ,
                                                 "The state of the polymeric material is specified.. This property is crucial for understanding how the material behaves under different conditions and its suitability for various applications."@en ;
                                 skos:prefLabel "Estado do Polímero"@pt-br ,
                                                "Polymer State"@en ;
-                                :hasAttributeScope :TypeLevelAttribute ;
-                                :hasTypedValue :stringValue ;
-                                :hasValueCardinality :multiValue .
+                                edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                edo:hasTypedValue edo:stringValue ;
+                                edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#PermeabilityTable_Temperature
-:PermeabilityTable_Temperature rdf:type owl:Class ;
-                               rdfs:subClassOf :PermeabilityTableAttribute ;
+edo:PermeabilityTable_Temperature rdf:type owl:Class ;
+                               rdfs:subClassOf edo:PermeabilityTableAttribute ;
                                dcterms:accessRights "PUBLIC" ;
                                dcterms:identifier "PermeabilityTable_Temperature" ;
                                skos:definition "Represents the thermal condition or measurement of heat for a component or system. This property is important for assessing how the component performs or operates under specific thermal conditions, ensuring it remains within safe and effective operating limits."@en ;
                                skos:prefLabel "Temperatura"@pt-br ,
                                               "Temperature"@en ;
-                               :hasAttributeScope :TypeLevelAttribute ;
-                               :hasTypedValue :floatValue ;
-                               :hasValueCardinality :multiValue .
+                               edo:hasAttributeScope edo:TypeLevelAttribute ;
+                               edo:hasTypedValue edo:floatValue ;
+                               edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#PhysicalConnection
-:PhysicalConnection rdf:type owl:Class ;
-                    rdfs:subClassOf :Connection ;
+edo:PhysicalConnection rdf:type owl:Class ;
+                    rdfs:subClassOf edo:Connection ;
                     dcterms:identifier "PhysicalConnection" ;
                     skos:definition "A Physical Connection refers to the actual link or interface between two or more components, such as pipes, equipment, or systems, that allows for the transfer of fluids, energy, or data."@en ;
                     skos:prefLabel "Conexão Física"@pt-br ,
@@ -4632,8 +4631,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#PhysicalPropertyAttribute
-:PhysicalPropertyAttribute rdf:type owl:Class ;
-                           rdfs:subClassOf :AttributeDomainCategory ;
+edo:PhysicalPropertyAttribute rdf:type owl:Class ;
+                           rdfs:subClassOf edo:AttributeDomainCategory ;
                            rdfs:comment "Represents intrinsic physical properties such as mass, density, material."@en ;
                            rdfs:label "Atributo de Propriedade Física"@pt-br ,
                                       "Physical Property Attribute"@en ;
@@ -4642,48 +4641,48 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#Piggable
-:Piggable rdf:type owl:Class ;
-          rdfs:subClassOf :DomainAttribute ;
+edo:Piggable rdf:type owl:Class ;
+          rdfs:subClassOf edo:DomainAttribute ;
           dcterms:accessRights "PUBLIC" ;
           dcterms:identifier "Piggable" ;
           skos:definition "Especifica se o equipamento possui pelo menos um circuito interno de escoamento que permita passagem de pig"@pt-br ,
                           "Whether equipment has at least one internal flow circuit allowing pig runs"@en ;
           skos:prefLabel "Piggable"@en ,
                          "Pigável"@pt-br ;
-          :hasAttributeScope :TypeLevelAttribute ;
-          :hasTypedValue :booleanValue ;
-          :hasValueCardinality :singleValue .
+          edo:hasAttributeScope edo:TypeLevelAttribute ;
+          edo:hasTypedValue edo:booleanValue ;
+          edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#Pile
-:Pile rdf:type owl:Class ;
-      rdfs:subClassOf :Anchor ;
+edo:Pile rdf:type owl:Class ;
+      rdfs:subClassOf edo:Anchor ;
       dcterms:identifier "Pile" .
 
 
 ###  https://w3id.org/energy-domain/edo#PipeMechanicalSupport
-:PipeMechanicalSupport rdf:type owl:Class ;
-                       rdfs:subClassOf :PipeSupport ;
+edo:PipeMechanicalSupport rdf:type owl:Class ;
+                       rdfs:subClassOf edo:PipeSupport ;
                        dcterms:identifier "PipeMechanicalSupport" .
 
 
 ###  https://w3id.org/energy-domain/edo#PipeMountPosition
-:PipeMountPosition rdf:type owl:Class ;
-                   rdfs:subClassOf :DomainAttribute ;
+edo:PipeMountPosition rdf:type owl:Class ;
+                   rdfs:subClassOf edo:DomainAttribute ;
                    dcterms:accessRights "PUBLIC" ;
                    dcterms:identifier "PipeMountPosition" ;
                    skos:definition "Cota em metros da posição em que o item é montado no tramo no sentido do fluxo do fluido."@pt-br ,
                                    "Indicates the distance from the end fitting to the position of the accessory along the direction of fluid flow within the pipe body. This property specifies the precise location of the accessory relative to the end fitting, which is essential for accurate installation and alignment within the tubular body."@en ;
                    skos:prefLabel "Pipe Mount Position"@en ,
                                   "Posição de Montagem no Duto"@pt-br ;
-                   :hasAttributeScope :InstanceLevelAttribute ;
-                   :hasTypedValue :floatValue ;
-                   :hasValueCardinality :singleValue .
+                   edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                   edo:hasTypedValue edo:floatValue ;
+                   edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#PipePullingHead
-:PipePullingHead rdf:type owl:Class ;
-                 rdfs:subClassOf :PullingHead ;
+edo:PipePullingHead rdf:type owl:Class ;
+                 rdfs:subClassOf edo:PullingHead ;
                  dcterms:identifier "PipePullingHead" ;
                  skos:altLabel "Cable Head"@en ,
                                "Installation Head"@en ,
@@ -4693,38 +4692,38 @@ rdf:value rdf:type owl:DatatypeProperty .
                  skos:definition "A component used in subsea flexible pipe installations to provide a secure attachment point for pulling the pipe into position during installation or retrieval operations. The Pulling Head is fitted to the end of the flexible pipe, allowing connection to pulling equipment such as winches or cranes. It is designed to withstand high loads, ensuring that the pipe can be pulled safely without causing damage. The Pulling Head is essential for handling, testing, and securing the pipe in place during subsea installation."@en ;
                  skos:prefLabel "Cabeça de Tração do Duto"@pt-br ,
                                 "Pipe Pulling Head"@en ;
-                 :hasAttribute :FlangeType ,
-                               :PullingHeadType ,
-                               :RingGasketInnerDIameter ,
-                               :RingGasketMaterial ,
-                               :RingGasketOuterDiameter ,
-                               :RingGasketPressureRating ,
-                               :RingGasketSpecification ,
-                               :RingGasketStandard ,
-                               :RingGasketType ,
-                               :SafeWorkingLoad ;
-                 :ifc_equivalentClass "IfcPipeFitting" ;
-                 :ifc_objectType "PipePullingHead" ;
-                 :ifc_predefinedType "USERDEFINED" .
+                 edo:hasAttribute edo:FlangeType ,
+                               edo:PullingHeadType ,
+                               edo:RingGasketInnerDIameter ,
+                               edo:RingGasketMaterial ,
+                               edo:RingGasketOuterDiameter ,
+                               edo:RingGasketPressureRating ,
+                               edo:RingGasketSpecification ,
+                               edo:RingGasketStandard ,
+                               edo:RingGasketType ,
+                               edo:SafeWorkingLoad ;
+                 edo:ifc_equivalentClass "IfcPipeFitting" ;
+                 edo:ifc_objectType "PipePullingHead" ;
+                 edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#PipeSectionApplication
-:PipeSectionApplication rdf:type owl:Class ;
-                        rdfs:subClassOf :DomainAttribute ;
+edo:PipeSectionApplication rdf:type owl:Class ;
+                        rdfs:subClassOf edo:DomainAttribute ;
                         dcterms:accessRights "PUBLIC" ;
                         dcterms:identifier "PipeSectionApplication" ;
                         skos:definition "Aplicação do tramo, de acordo com as seguintes nomenclaturas: R (Riser); RT (seção de topo do riser); RI (seção intermediaria do riser); RF (seção de fundo do riser); F (Flowline)"@pt-br ,
                                         "Indicates the specific application of the flexible pipe section in the interconnection system, categorizing it based on its role or position within the riser or flowline."@en ;
                         skos:prefLabel "Aplicação do Tramo"@pt-br ,
                                        "Pipe Section Application"@en ;
-                        :hasAttributeScope :InstanceLevelAttribute ;
-                        :hasTypedValue :stringValue ;
-                        :hasValueCardinality :singleValue .
+                        edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                        edo:hasTypedValue edo:stringValue ;
+                        edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#PipeSegment
-:PipeSegment rdf:type owl:Class ;
-             rdfs:subClassOf :TransportLineSegment ;
+edo:PipeSegment rdf:type owl:Class ;
+             rdfs:subClassOf edo:TransportLineSegment ;
              dcterms:identifier "PipeSegment" ;
              skos:definition "Pipeline segment for movement/flow of fluids."@en ,
                              "Segmento de Duto"@pt-br ;
@@ -4733,14 +4732,14 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#PipeSupport
-:PipeSupport rdf:type owl:Class ;
-             rdfs:subClassOf :Structure ;
+edo:PipeSupport rdf:type owl:Class ;
+             rdfs:subClassOf edo:Structure ;
              dcterms:identifier "PipeSupport" .
 
 
 ###  https://w3id.org/energy-domain/edo#PipeTermination
-:PipeTermination rdf:type owl:Class ;
-                 rdfs:subClassOf :LineTermination ;
+edo:PipeTermination rdf:type owl:Class ;
+                 rdfs:subClassOf edo:LineTermination ;
                  dcterms:identifier "PipeTermination" ;
                  skos:definition "The Pipe Termination refers to the components at the end of a pipeline that provide the final connection to other equipment or systems. These terminations are crucial for ensuring a secure and reliable interface between the pipeline and surrounding infrastructure, allowing for the proper transfer of fluids or gases and maintaining the integrity of the overall system."@en ;
                  skos:prefLabel "Pipe Termination"@en ,
@@ -4748,54 +4747,54 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#PipelineSpan
-:PipelineSpan rdf:type owl:Class ;
-              rdfs:subClassOf :LineSpan ;
+edo:PipelineSpan rdf:type owl:Class ;
+              rdfs:subClassOf edo:LineSpan ;
               dcterms:identifier "PipelineSpan" .
 
 
 ###  https://w3id.org/energy-domain/edo#PipingSpool
-:PipingSpool rdf:type owl:Class ;
-             rdfs:subClassOf :PressureComponent ;
+edo:PipingSpool rdf:type owl:Class ;
+             rdfs:subClassOf edo:PressureComponent ;
              dcterms:identifier "PipingSpool" .
 
 
 ###  https://w3id.org/energy-domain/edo#PitchToleranceClass
-:PitchToleranceClass rdf:type owl:Class ;
-                     rdfs:subClassOf :DomainAttribute ;
+edo:PitchToleranceClass rdf:type owl:Class ;
+                     rdfs:subClassOf edo:DomainAttribute ;
                      dcterms:accessRights "PUBLIC" ;
                      dcterms:identifier "PitchToleranceClass" ;
                      skos:definition "A classification defining the acceptable deviation range for the pitch measurement, ensuring consistency in the helical arrangement of wires or threads."@en ;
                      skos:prefLabel "Classe de Tolerância de Passo"@pt-br ,
                                     "Pitch Tolerance Class"@en ;
-                     :hasAttributeScope :InstanceLevelAttribute ;
-                     :hasTypedValue :stringValue ;
-                     :hasValueCardinality :singleValue .
+                     edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                     edo:hasTypedValue edo:stringValue ;
+                     edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#Planned_Start_Timestamp
-:Planned_Start_Timestamp rdf:type owl:Class ;
-                         rdfs:subClassOf :DomainAttribute ;
+edo:Planned_Start_Timestamp rdf:type owl:Class ;
+                         rdfs:subClassOf edo:DomainAttribute ;
                          dcterms:accessRights "PUBLIC" ;
                          dcterms:identifier "Planned_Start_Timestamp" ;
                          skos:prefLabel "Planned Start Timestamp"@en ;
-                         :hasAttributeScope :InstanceLevelAttribute ;
-                         :hasTypedValue :dateTimeValue ;
-                         :hasValueCardinality :singleValue .
+                         edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                         edo:hasTypedValue edo:dateTimeValue ;
+                         edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#PlasticHose
-:PlasticHose rdf:type owl:Class ;
-             rdfs:subClassOf :Tubing ;
+edo:PlasticHose rdf:type owl:Class ;
+             rdfs:subClassOf edo:Tubing ;
              dcterms:identifier "PlasticHose" ;
              skos:prefLabel "Plastic Hose"@en ;
-             :ifc_equivalentClass "IfcPipeSegment" ;
-             :ifc_objectType "PlasticHose" ;
-             :ifc_predefinedType "USERDEFINED" .
+             edo:ifc_equivalentClass "IfcPipeSegment" ;
+             edo:ifc_objectType "PlasticHose" ;
+             edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#PointLocation
-:PointLocation rdf:type owl:Class ;
-               rdfs:subClassOf :Location ;
+edo:PointLocation rdf:type owl:Class ;
+               rdfs:subClassOf edo:Location ;
                dcterms:identifier "PointLocation" ;
                skos:definition "Basis for all locations that can conventionally be situated at a single geographic point."@en ;
                skos:prefLabel "Localização de Ponto"@pt-br ,
@@ -4803,85 +4802,85 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#PoissonRatioAt23Degrees
-:PoissonRatioAt23Degrees rdf:type owl:Class ;
-                         rdfs:subClassOf :DomainAttribute ;
+edo:PoissonRatioAt23Degrees rdf:type owl:Class ;
+                         rdfs:subClassOf edo:DomainAttribute ;
                          dcterms:accessRights "PUBLIC" ;
                          dcterms:identifier "PoissonRatioAt23Degrees" ;
                          skos:definition "Coeficiente de Poisson a 23 graus Celsius (Específica para Materiais Metálicos e Poliméricos)"@pt-br ,
                                          "Indicates Poisson's ratio of the material at 23 degrees Celsius, representing the ratio of transverse strain to axial strain when the material is subjected to stress. This property is essential for understanding the material's deformation behavior under load and its response to mechanical forces in subsea environments."@en ;
                          skos:prefLabel "Coeficiente de Poisson a 23 Graus Celsius"@pt-br ,
                                         "Poisson Ratio At 23 Degrees"@en ;
-                         :hasAttributeScope :TypeLevelAttribute ;
-                         :hasTypedValue :floatValue ;
-                         :hasValueCardinality :singleValue .
+                         edo:hasAttributeScope edo:TypeLevelAttribute ;
+                         edo:hasTypedValue edo:floatValue ;
+                         edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#PolymericLayerMaterialType
-:PolymericLayerMaterialType rdf:type owl:Class ;
-                            rdfs:subClassOf :DomainAttribute ;
+edo:PolymericLayerMaterialType rdf:type owl:Class ;
+                            rdfs:subClassOf edo:DomainAttribute ;
                             dcterms:accessRights "PUBLIC" ;
                             dcterms:identifier "PolymericLayerMaterialType" ;
                             skos:definition "Type of material from which an object is made, allowing for precise documentation and categorisation."@en ;
                             skos:prefLabel "Polymeric Layer Material Type"@en ,
                                            "Tipo de Material da Camada Polimérica"@pt-br ;
-                            :hasAttributeScope :TypeLevelAttribute ;
-                            :hasTypedValue :stringValue ;
-                            :hasValueCardinality :singleValue .
+                            edo:hasAttributeScope edo:TypeLevelAttribute ;
+                            edo:hasTypedValue edo:stringValue ;
+                            edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#PolymericMaterial
-:PolymericMaterial rdf:type owl:Class ;
-                   rdfs:subClassOf :FlexibleStructureLayerMaterial ;
+edo:PolymericMaterial rdf:type owl:Class ;
+                   rdfs:subClassOf edo:FlexibleStructureLayerMaterial ;
                    dcterms:identifier "PolymericMaterial" ;
                    skos:definition "Material made from polymers, used to fabricate flexible layers in subsea flexible pipes. Polymeric Material is selected for its properties such as flexibility, chemical resistance, and durability, making it suitable for withstanding the harsh conditions of subsea environments. These materials are commonly used in layers that provide insulation, protection, or pressure containment, ensuring the overall performance and integrity of the flexible pipe under dynamic loads and extreme underwater conditions."@en ;
                    skos:prefLabel "Material Polimérico"@pt-br ,
                                   "Polymeric Material"@en ;
-                   :hasAttribute :DiffusionTable ,
-                                 :DiffusionTable_DiffusionCoefficient ,
-                                 :DiffusionTable_MoleculeIdentifier ,
-                                 :DiffusionTable_PolymerState ,
-                                 :DiffusionTable_Temperature ,
-                                 :EModVsTempTable_ElasticityModulus ,
-                                 :MaxPermissibleDeformationDynamic ,
-                                 :MaxPermissibleDeformationStatic ,
-                                 :MinimumTemperature ,
-                                 :PermeabilityTable ,
-                                 :PermeabilityTable_MoleculeIdentifier ,
-                                 :PermeabilityTable_PermeabilityCoefficient ,
-                                 :PermeabilityTable_PolymerState ,
-                                 :PermeabilityTable_Temperature ,
-                                 :PolymericLayerMaterialType ,
-                                 :SolubilityTable ,
-                                 :SolubilityTable_MoleculeIdentifier ,
-                                 :SolubilityTable_PolymerState ,
-                                 :SolubilityTable_SolubilityCoefficient ,
-                                 :SolubilityTable_Temperature ;
-                   :ifc_equivalentClass "IfcMaterial" ;
-                   :ifc_objectType "PolymericMaterial" .
+                   edo:hasAttribute edo:DiffusionTable ,
+                                 edo:DiffusionTable_DiffusionCoefficient ,
+                                 edo:DiffusionTable_MoleculeIdentifier ,
+                                 edo:DiffusionTable_PolymerState ,
+                                 edo:DiffusionTable_Temperature ,
+                                 edo:EModVsTempTable_ElasticityModulus ,
+                                 edo:MaxPermissibleDeformationDynamic ,
+                                 edo:MaxPermissibleDeformationStatic ,
+                                 edo:MinimumTemperature ,
+                                 edo:PermeabilityTable ,
+                                 edo:PermeabilityTable_MoleculeIdentifier ,
+                                 edo:PermeabilityTable_PermeabilityCoefficient ,
+                                 edo:PermeabilityTable_PolymerState ,
+                                 edo:PermeabilityTable_Temperature ,
+                                 edo:PolymericLayerMaterialType ,
+                                 edo:SolubilityTable ,
+                                 edo:SolubilityTable_MoleculeIdentifier ,
+                                 edo:SolubilityTable_PolymerState ,
+                                 edo:SolubilityTable_SolubilityCoefficient ,
+                                 edo:SolubilityTable_Temperature ;
+                   edo:ifc_equivalentClass "IfcMaterial" ;
+                   edo:ifc_objectType "PolymericMaterial" .
 
 
 ###  https://w3id.org/energy-domain/edo#PostSlippingBendingStiffness
-:PostSlippingBendingStiffness rdf:type owl:Class ;
-                              rdfs:subClassOf :BendingStiffnessAttribute ;
+edo:PostSlippingBendingStiffness rdf:type owl:Class ;
+                              rdfs:subClassOf edo:BendingStiffnessAttribute ;
                               dcterms:accessRights "PUBLIC" ;
                               dcterms:identifier "PostSlippingBendingStiffness" ;
                               skos:definition "Represents the stiffness of a component after slipping occurs during bending. This property is important for evaluating the structural response and stability of the component once it has experienced slippage, ensuring that it can still withstand bending loads without significant deformation."@en ;
                               skos:prefLabel "Post Slipping Bending Stiffness"@en ,
                                              "Rigidez de Flexão Pós-Escorregamento"@pt-br ;
-                              :hasAttributeScope :TypeLevelAttribute ;
-                              :hasTypedValue :floatValue ;
-                              :hasValueCardinality :singleValue .
+                              edo:hasAttributeScope edo:TypeLevelAttribute ;
+                              edo:hasTypedValue edo:floatValue ;
+                              edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#PowerMachine
-:PowerMachine rdf:type owl:Class ;
-              rdfs:subClassOf :PressureComponent ;
+edo:PowerMachine rdf:type owl:Class ;
+              rdfs:subClassOf edo:PressureComponent ;
               dcterms:identifier "PowerMachine" .
 
 
 ###  https://w3id.org/energy-domain/edo#PreCommissioning
-:PreCommissioning rdf:type owl:Class ;
-                  rdfs:subClassOf :LifecyclePhase ;
+edo:PreCommissioning rdf:type owl:Class ;
+                  rdfs:subClassOf edo:LifecyclePhase ;
                   rdfs:label "Pre-Commissioning"@en ,
                              "Pré-Comissionamento"@pt-br ;
                   skos:definition "Verification and functional testing before introducing operational fluids or energy."@en ,
@@ -4889,51 +4888,51 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#PreSlippingBendingStiffness
-:PreSlippingBendingStiffness rdf:type owl:Class ;
-                             rdfs:subClassOf :BendingStiffnessAttribute ;
+edo:PreSlippingBendingStiffness rdf:type owl:Class ;
+                             rdfs:subClassOf edo:BendingStiffnessAttribute ;
                              dcterms:accessRights "PUBLIC" ;
                              dcterms:identifier "PreSlippingBendingStiffness" ;
                              skos:definition "Represents the stiffness of a component before any slipping occurs during bending. This property is important for assessing how the component resists bending forces prior to slippage, ensuring that it maintains its shape and performance under load."@en ;
                              skos:prefLabel "Pre Slipping Bending Stiffness"@en ,
                                             "Rigidez de Flexão Pré-Escorregamento"@pt-br ;
-                             :hasAttributeScope :TypeLevelAttribute ;
-                             :hasTypedValue :floatValue ;
-                             :hasValueCardinality :singleValue .
+                             edo:hasAttributeScope edo:TypeLevelAttribute ;
+                             edo:hasTypedValue edo:floatValue ;
+                             edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#PressureArmour
-:PressureArmour rdf:type owl:Class ;
-                rdfs:subClassOf :CarcassLayer ;
+edo:PressureArmour rdf:type owl:Class ;
+                rdfs:subClassOf edo:CarcassLayer ;
                 dcterms:identifier "PressureArmour" ;
                 skos:definition "A high-strength, metallic layer used in subsea flexible pipes to provide resistance against both internal and external pressure. The Pressure Armour prevents the pipe from expanding under high internal pressures and protects against collapse due to external pressure. Typically made from helically wound steel or other strong materials, it supports the pipe's structural integrity and ensures reliable operation in harsh subsea environments."@en ;
                 skos:prefLabel "Armadura de Pressão"@pt-br ,
                                "Pressure Armour"@en ;
-                :ifc_equivalentClass "IfcPipeSegment" ;
-                :ifc_objectType "PressureArmour" ;
-                :ifc_predefinedType "USERDEFINED" .
+                edo:ifc_equivalentClass "IfcPipeSegment" ;
+                edo:ifc_objectType "PressureArmour" ;
+                edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#PressureComponent
-:PressureComponent rdf:type owl:Class ;
-                   rdfs:subClassOf :ComponentDevice ;
+edo:PressureComponent rdf:type owl:Class ;
+                   rdfs:subClassOf edo:ComponentDevice ;
                    dcterms:identifier "PressureComponent" .
 
 
 ###  https://w3id.org/energy-domain/edo#PressureEquipment
-:PressureEquipment rdf:type owl:Class ;
-                   rdfs:subClassOf :ActuatedEquipment ;
+edo:PressureEquipment rdf:type owl:Class ;
+                   rdfs:subClassOf edo:ActuatedEquipment ;
                    dcterms:identifier "PressureEquipment" .
 
 
 ###  https://w3id.org/energy-domain/edo#PressureSensor
-:PressureSensor rdf:type owl:Class ;
-                rdfs:subClassOf :Sensor ;
+edo:PressureSensor rdf:type owl:Class ;
+                rdfs:subClassOf edo:Sensor ;
                 dcterms:identifier "PressureSensor" .
 
 
 ###  https://w3id.org/energy-domain/edo#ProcessEngineering
-:ProcessEngineering rdf:type owl:Class ;
-                    rdfs:subClassOf :TechnicalDiscipline ;
+edo:ProcessEngineering rdf:type owl:Class ;
+                    rdfs:subClassOf edo:TechnicalDiscipline ;
                     rdfs:label "Engenharia de Processos"@pt-br ,
                                "Process Engineering"@en ;
                     skos:definition "Disciplina de engenharia focada no projeto e otimização de processos industriais."@pt-br ,
@@ -4941,8 +4940,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#ProcessPipingEngineering
-:ProcessPipingEngineering rdf:type owl:Class ;
-                          rdfs:subClassOf :TechnicalDiscipline ;
+edo:ProcessPipingEngineering rdf:type owl:Class ;
+                          rdfs:subClassOf edo:TechnicalDiscipline ;
                           rdfs:label "Engenharia de Tubulação de Processo"@pt-br ,
                                      "Process Piping Engineering"@en ;
                           skos:definition "Disciplina de engenharia focada no projeto de sistemas de tubulação para fluidos de processo."@pt-br ,
@@ -4950,14 +4949,14 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#ProcessingModule
-:ProcessingModule rdf:type owl:Class ;
-                  rdfs:subClassOf :FlowControlModule ;
+edo:ProcessingModule rdf:type owl:Class ;
+                  rdfs:subClassOf edo:FlowControlModule ;
                   dcterms:identifier "ProcessingModule" .
 
 
 ###  https://w3id.org/energy-domain/edo#Procurement
-:Procurement rdf:type owl:Class ;
-             rdfs:subClassOf :LifecyclePhase ;
+edo:Procurement rdf:type owl:Class ;
+             rdfs:subClassOf edo:LifecyclePhase ;
              rdfs:label "Aquisição"@pt-br ,
                         "Procurement"@en ;
              skos:definition "Acquisition of materials, equipment, and services required for project execution."@en ,
@@ -4965,84 +4964,84 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#Project
-:Project rdf:type owl:Class ;
-         rdfs:subClassOf :DomainElement ;
+edo:Project rdf:type owl:Class ;
+         rdfs:subClassOf edo:DomainElement ;
          dcterms:identifier "Project" ;
          skos:definition "A broad concept that encompasses the design, development, and planning of various components or systems."@en ;
          skos:prefLabel "Project"@en ,
                         "Projeto"@pt-br ;
-         :ifc_equivalentClass "IfcProject" .
+         edo:ifc_equivalentClass "IfcProject" .
 
 
 ###  https://w3id.org/energy-domain/edo#ProjectAcronym
-:ProjectAcronym rdf:type owl:Class ;
-                rdfs:subClassOf :DomainAttribute ;
+edo:ProjectAcronym rdf:type owl:Class ;
+                rdfs:subClassOf edo:DomainAttribute ;
                 dcterms:accessRights "PUBLIC" ;
                 dcterms:identifier "ProjectAcronym" ;
                 skos:definition "Abreviação do nome do projeto da Interligação Submarina. Ex., 'SEP' para o \"FPSO Carioca do campo de Sépia\""@pt-br ,
                                 "Indicates the unique identification code assigned to the operator's project. This property is used for tracking, managing, and referencing the project throughout all phases of its lifecycle, ensuring proper identification and organization."@en ;
                 skos:prefLabel "Abreviação do Nome do Projeto da Interligação Submarina"@pt-br ,
                                "Project Acronym"@en ;
-                :hasAttributeScope :InstanceLevelAttribute ;
-                :hasTypedValue :stringValue ;
-                :hasValueCardinality :singleValue .
+                edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                edo:hasTypedValue edo:stringValue ;
+                edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#ProjectCode
-:ProjectCode rdf:type owl:Class ;
-             rdfs:subClassOf :DomainAttribute ;
+edo:ProjectCode rdf:type owl:Class ;
+             rdfs:subClassOf edo:DomainAttribute ;
              dcterms:accessRights "PUBLIC" ;
              dcterms:identifier "ProjectCode" ;
              skos:definition "Unique identification code assigned to the operator's project, used for tracking, managing, and referencing the project across all phases of its lifecycle."@en ;
              skos:prefLabel "Código Identificador único do projeto da operadora da Interligação Submarina"@pt-br ,
                             "Project Code"@en ;
-             :hasAttributeScope :InstanceLevelAttribute ;
-             :hasTypedValue :stringValue ;
-             :hasValueCardinality :singleValue .
+             edo:hasAttributeScope edo:InstanceLevelAttribute ;
+             edo:hasTypedValue edo:stringValue ;
+             edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#ProjectDrawingCode
-:ProjectDrawingCode rdf:type owl:Class ;
-                    rdfs:subClassOf :DomainAttribute ;
+edo:ProjectDrawingCode rdf:type owl:Class ;
+                    rdfs:subClassOf edo:DomainAttribute ;
                     dcterms:accessRights "PUBLIC" ;
                     dcterms:identifier "ProjectDrawingCode" ;
                     skos:definition "Indicates the unique alphanumeric code assigned to the project drawing. This property is used to reference and locate the specific drawing associated with the item, providing a clear and organized method for tracking and accessing drawing documents."@en ,
                                     "Número do desenho do projeto do acessório"@pt-br ;
                     skos:prefLabel "Número do Desenho do Projeto"@pt-br ,
                                    "Project Drawing Code"@en ;
-                    :hasAttributeScope :TypeLevelAttribute ;
-                    :hasTypedValue :stringValue ;
-                    :hasValueCardinality :singleValue .
+                    edo:hasAttributeScope edo:TypeLevelAttribute ;
+                    edo:hasTypedValue edo:stringValue ;
+                    edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#ProjectDrawingRevision
-:ProjectDrawingRevision rdf:type owl:Class ;
-                        rdfs:subClassOf :DomainAttribute ;
+edo:ProjectDrawingRevision rdf:type owl:Class ;
+                        rdfs:subClassOf edo:DomainAttribute ;
                         dcterms:accessRights "PUBLIC" ;
                         dcterms:identifier "ProjectDrawingRevision" ;
                         skos:definition "Indicates the revision number or identifier of the project drawing. This property tracks the version of the drawing, providing essential information for identifying updates, changes, and the most current version of the drawing related to the item."@en ;
                         skos:prefLabel "Project Drawing Revision"@en ,
                                        "Revisão do Desenho do Projeto"@pt-br ;
-                        :hasAttributeScope :TypeLevelAttribute ;
-                        :hasTypedValue :stringValue ;
-                        :hasValueCardinality :singleValue .
+                        edo:hasAttributeScope edo:TypeLevelAttribute ;
+                        edo:hasTypedValue edo:stringValue ;
+                        edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#ProtectiveSheath
-:ProtectiveSheath rdf:type owl:Class ;
-                  rdfs:subClassOf :SolidLayer ;
+edo:ProtectiveSheath rdf:type owl:Class ;
+                  rdfs:subClassOf edo:SolidLayer ;
                   dcterms:identifier "ProtectiveSheath" ;
                   skos:definition "A layer in subsea flexible pipes designed to shield internal components from external environmental factors such as abrasion, mechanical damage, or chemical exposure. The Protective Sheath serves as the outermost barrier, providing defense against harsh subsea conditions while preserving the integrity of the underlying layers. Typically made from durable polymeric materials, it plays a critical role in extending the lifespan of the flexible pipe by protecting it from physical and chemical wear."@en ;
                   skos:prefLabel "Capa de Proteção"@pt-br ,
                                  "Protective Sheath"@en ;
-                  :ifc_equivalentClass "IfcPipeSegment" ;
-                  :ifc_objectType "ProtectiveSheath" ;
-                  :ifc_predefinedType "USERDEFINED" .
+                  edo:ifc_equivalentClass "IfcPipeSegment" ;
+                  edo:ifc_objectType "ProtectiveSheath" ;
+                  edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#PullInCollar
-:PullInCollar rdf:type owl:Class ;
-              rdfs:subClassOf :SplitCollar ;
+edo:PullInCollar rdf:type owl:Class ;
+              rdfs:subClassOf edo:SplitCollar ;
               dcterms:identifier "PullInCollar" ;
               skos:altLabel "Installation Collar"@en ,
                             "Pull-In Clamp"@en ,
@@ -5051,17 +5050,17 @@ rdf:value rdf:type owl:DatatypeProperty .
               skos:definition "A device used in subsea operations to assist in the installation of flexible pipes or risers by providing a secure attachment point for pulling the pipe into position. The Pull In Collar is typically installed around the pipe and serves as a handling point for pulling equipment during installation. It ensures a controlled and secure method of pulling the pipe into place, preventing damage to the pipe while facilitating smooth and efficient installation in subsea environments."@en ;
               skos:prefLabel "Colar de Pull In"@pt-br ,
                              "Pull In Collar"@en ;
-              :hasAttribute :WireRopeQuantity ,
-                            :WireRopeSlingDiameter ,
-                            :WireRopeSlingLength ;
-              :ifc_equivalentClass "IfcPipeFitting" ;
-              :ifc_objectType "PullInCollar" ;
-              :ifc_predefinedType "USERDEFINED" .
+              edo:hasAttribute edo:WireRopeQuantity ,
+                            edo:WireRopeSlingDiameter ,
+                            edo:WireRopeSlingLength ;
+              edo:ifc_equivalentClass "IfcPipeFitting" ;
+              edo:ifc_objectType "PullInCollar" ;
+              edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#PullingHead
-:PullingHead rdf:type owl:Class ;
-             rdfs:subClassOf :LineAncillary ;
+edo:PullingHead rdf:type owl:Class ;
+             rdfs:subClassOf edo:LineAncillary ;
              dcterms:identifier "PullingHead" ;
              skos:altLabel "Cable Head"@en ,
                            "Installation Head"@en ,
@@ -5073,69 +5072,69 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#PullingHeadType
-:PullingHeadType rdf:type owl:Class ;
-                 rdfs:subClassOf :DomainAttribute ;
+edo:PullingHeadType rdf:type owl:Class ;
+                 rdfs:subClassOf edo:DomainAttribute ;
                  dcterms:accessRights "PUBLIC" ;
                  dcterms:identifier "PullingHeadType" ;
                  skos:definition "Specifies the type of pulling head used for the installation or retrieval of subsea flexible structures. It describes the design and functionality of the pulling head, including details such as compatibility with specific installation methods, mechanical connections, and any special features or adaptations for handling loads during pulling operations. This property helps to ensure the correct pulling head is selected based on the requirements of the project and the conditions of the installation site."@en ;
                  skos:prefLabel "Pulling Head Type"@en ,
                                 "Tipo de Cabeça de Tração"@pt-br ;
-                 :hasAttributeScope :TypeLevelAttribute ;
-                 :hasTypedValue :stringValue ;
-                 :hasValueCardinality :singleValue .
+                 edo:hasAttributeScope edo:TypeLevelAttribute ;
+                 edo:hasTypedValue edo:stringValue ;
+                 edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#Pump
-:Pump rdf:type owl:Class ;
-      rdfs:subClassOf :RotatingMachine ;
+edo:Pump rdf:type owl:Class ;
+      rdfs:subClassOf edo:RotatingMachine ;
       dcterms:identifier "Pump" .
 
 
 ###  https://w3id.org/energy-domain/edo#PumpingModule
-:PumpingModule rdf:type owl:Class ;
-               rdfs:subClassOf :ProcessingModule ;
+edo:PumpingModule rdf:type owl:Class ;
+               rdfs:subClassOf edo:ProcessingModule ;
                dcterms:identifier "PumpingModule" .
 
 
 ###  https://w3id.org/energy-domain/edo#Quantity
-:Quantity rdf:type owl:Class ;
-          rdfs:subClassOf :DomainAttribute ;
+edo:Quantity rdf:type owl:Class ;
+          rdfs:subClassOf edo:DomainAttribute ;
           dcterms:accessRights "PUBLIC" ;
           dcterms:identifier "Quantity" ;
           skos:definition "Quantity of items."@en ;
           skos:prefLabel "Quantidade de Itens"@pt-br ,
                          "Quantity"@en ;
-          :hasAttributeScope :InstanceLevelAttribute ;
-          :hasTypedValue :intValue ;
-          :hasValueCardinality :singleValue .
+          edo:hasAttributeScope edo:InstanceLevelAttribute ;
+          edo:hasTypedValue edo:intValue ;
+          edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#QuickDisconnectionTool
-:QuickDisconnectionTool rdf:type owl:Class ;
-                        rdfs:subClassOf :RunningTool ;
+edo:QuickDisconnectionTool rdf:type owl:Class ;
+                        rdfs:subClassOf edo:RunningTool ;
                         dcterms:identifier "QuickDisconnectionTool" .
 
 
 ###  https://w3id.org/energy-domain/edo#ROVTool
-:ROVTool rdf:type owl:Class ;
-         rdfs:subClassOf :Accessory ;
+edo:ROVTool rdf:type owl:Class ;
+         rdfs:subClassOf edo:Accessory ;
          dcterms:identifier "ROVTool" .
 
 ###  https://w3id.org/energy-domain/edo#RearPoint
-:RearPoint rdf:type owl:Class ;
-           rdfs:subClassOf :SupportRegion ;
+edo:RearPoint rdf:type owl:Class ;
+           rdfs:subClassOf edo:SupportRegion ;
            dcterms:identifier "RearPoint" ;
              skos:definition "Ponto na linha de centro do End Fitting para indicar a posição de suporte traseiro"@pt-br ,
                              "The rear part of the component can be used to lock the End Fitting during onboard installation, ensuring that it remains securely in place during the process. The Rear Point provides a reference point on the rear part along the center line of the End Fitting, facilitating the precise alignment and positioning required for a smooth installation."@en ;
              skos:prefLabel "Rear Point"@en ,
                             "Ponto de Traseiro"@pt-br ;
-             :ifc_equivalentClass "IfcDistributionPort" ;
-             :ifc_objectType "RearPoint" ;
-             :ifc_predefinedType "USERDEFINED" . 
+             edo:ifc_equivalentClass "IfcDistributionPort" ;
+             edo:ifc_objectType "RearPoint" ;
+             edo:ifc_predefinedType "USERDEFINED" . 
 
 ###  https://w3id.org/energy-domain/edo#Recycling
-:Recycling rdf:type owl:Class ;
-           rdfs:subClassOf :LifecyclePhase ;
+edo:Recycling rdf:type owl:Class ;
+           rdfs:subClassOf edo:LifecyclePhase ;
            rdfs:label "Reciclagem"@pt-br ,
                       "Recycling"@en ;
            skos:definition "Processamento e reutilização de materiais recuperados durante o descomissionamento."@pt-br ,
@@ -5143,8 +5142,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#ReferenceDrawing
-:ReferenceDrawing rdf:type owl:Class ;
-                  rdfs:subClassOf :DomainElement ;
+edo:ReferenceDrawing rdf:type owl:Class ;
+                  rdfs:subClassOf edo:DomainElement ;
                   dcterms:identifier "ReferenceDrawing" ;
                   skos:definition "A technical drawing providing detailed information about a specific component, system, or assembly, used as a guide for manufacturing, installation, or maintenance in subsea projects."@en ;
                   skos:prefLabel "Desenhos de Referência"@pt-br ,
@@ -5152,19 +5151,19 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#Registry_GUIDAttribute
-:Registry_GUIDAttribute rdf:type owl:Class ;
-                        rdfs:subClassOf :DomainAttribute .
+edo:Registry_GUIDAttribute rdf:type owl:Class ;
+                        rdfs:subClassOf edo:DomainAttribute .
 
 
 ###  https://w3id.org/energy-domain/edo#ReliefValve
-:ReliefValve rdf:type owl:Class ;
-             rdfs:subClassOf :CheckValve ;
+edo:ReliefValve rdf:type owl:Class ;
+             rdfs:subClassOf edo:CheckValve ;
              dcterms:identifier "ReliefValve" .
 
 
 ###  https://w3id.org/energy-domain/edo#Renewable
-:Renewable rdf:type owl:Class ;
-           rdfs:subClassOf :Domain ;
+edo:Renewable rdf:type owl:Class ;
+           rdfs:subClassOf edo:Domain ;
            rdfs:label "Energia Renovável"@pt-br ,
                       "Renewable Energy"@en ;
            skos:definition "Domínio industrial que abrange fontes de energia que são naturalmente reabastecidas, como solar, eólica e hidrelétrica."@pt-br ,
@@ -5172,14 +5171,14 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#RigidJumper
-:RigidJumper rdf:type owl:Class ;
-             rdfs:subClassOf :TieInEquipment ;
+edo:RigidJumper rdf:type owl:Class ;
+             rdfs:subClassOf edo:TieInEquipment ;
              dcterms:identifier "RigidJumper" .
 
 
 ###  https://w3id.org/energy-domain/edo#RingGasket
-:RingGasket rdf:type owl:Class ;
-            rdfs:subClassOf :PhysicalConnection ;
+edo:RingGasket rdf:type owl:Class ;
+            rdfs:subClassOf edo:PhysicalConnection ;
             dcterms:identifier "RingGasket" ;
             skos:altLabel " Seal Ring"@en ,
                           "Gasket"@en ,
@@ -5190,125 +5189,125 @@ rdf:value rdf:type owl:DatatypeProperty .
             skos:definition "The seal ring is a crucial component used in subsea oil and gas interconnection end fittings to ensure a secure and leak-proof connection between pipes or equipment. Typically made from high-performance materials such as elastomers or metals, the seal ring is designed to withstand extreme pressure, temperature, and environmental conditions found in subsea operations. It is installed within the end fitting to create a reliable seal that prevents fluid leakage and maintains the integrity of the interconnection. The seal ring’s precise design and material selection are essential for ensuring long-term durability and performance in harsh subsea environments."@en ;
             skos:prefLabel "Junta de Conexão"@pt-br ,
                            "Ring Gasket"@en ;
-            :hasAttribute :RingGasketInnerDIameter ,
-                          :RingGasketMaterial ,
-                          :RingGasketOuterDiameter ,
-                          :RingGasketPressureRating ,
-                          :RingGasketSpecification ,
-                          :RingGasketStandard ,
-                          :RingGasketType ;
-            :ifc_equivalentClass "IfcMechanicalFastener" ;
-            :ifc_objectType "RingGasket" ;
-            :ifc_predefinedType "USERDEFINED" .
+            edo:hasAttribute edo:RingGasketInnerDIameter ,
+                          edo:RingGasketMaterial ,
+                          edo:RingGasketOuterDiameter ,
+                          edo:RingGasketPressureRating ,
+                          edo:RingGasketSpecification ,
+                          edo:RingGasketStandard ,
+                          edo:RingGasketType ;
+            edo:ifc_equivalentClass "IfcMechanicalFastener" ;
+            edo:ifc_objectType "RingGasket" ;
+            edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#RingGasketAttribute
-:RingGasketAttribute rdf:type owl:Class ;
-                     rdfs:subClassOf :DomainAttribute ;
+edo:RingGasketAttribute rdf:type owl:Class ;
+                     rdfs:subClassOf edo:DomainAttribute ;
                      rdfs:label "Ring Gasket"@en .
 
 
 ###  https://w3id.org/energy-domain/edo#RingGasketInnerDIameter
-:RingGasketInnerDIameter rdf:type owl:Class ;
-                         rdfs:subClassOf :RingGasketAttribute ;
+edo:RingGasketInnerDIameter rdf:type owl:Class ;
+                         rdfs:subClassOf edo:RingGasketAttribute ;
                          dcterms:accessRights "PUBLIC" ;
                          dcterms:identifier "RingGasketInnerDIameter" ;
                          skos:definition "The internal diameter, which determines the size of the bore it fits into. This dimension is crucial for ensuring a proper fit and effective sealing."@en ;
                          skos:prefLabel "Diâmetro Interno da Junta de Vedação"@pt-br ,
                                         "Ring Gasket Inner Diameter"@en ;
-                         :hasAttributeScope :InstanceLevelAttribute ,
-                                            :TypeLevelAttribute ;
-                         :hasTypedValue :floatValue ;
-                         :hasValueCardinality :singleValue .
+                         edo:hasAttributeScope edo:InstanceLevelAttribute ,
+                                            edo:TypeLevelAttribute ;
+                         edo:hasTypedValue edo:floatValue ;
+                         edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#RingGasketMaterial
-:RingGasketMaterial rdf:type owl:Class ;
-                    rdfs:subClassOf :RingGasketAttribute ;
+edo:RingGasketMaterial rdf:type owl:Class ;
+                    rdfs:subClassOf edo:RingGasketAttribute ;
                     dcterms:accessRights "PUBLIC" ;
                     dcterms:identifier "RingGasketMaterial" ;
                     skos:definition "Type of material from which an object is made, allowing for precise documentation and categorisation."@en ;
                     skos:prefLabel "Material da Junta de Vedação"@pt-br ,
                                    "Ring Gasket Material"@en ;
-                    :hasAttributeScope :InstanceLevelAttribute ,
-                                       :TypeLevelAttribute ;
-                    :hasTypedValue :stringValue ;
-                    :hasValueCardinality :singleValue .
+                    edo:hasAttributeScope edo:InstanceLevelAttribute ,
+                                       edo:TypeLevelAttribute ;
+                    edo:hasTypedValue edo:stringValue ;
+                    edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#RingGasketOuterDiameter
-:RingGasketOuterDiameter rdf:type owl:Class ;
-                         rdfs:subClassOf :RingGasketAttribute ;
+edo:RingGasketOuterDiameter rdf:type owl:Class ;
+                         rdfs:subClassOf edo:RingGasketAttribute ;
                          dcterms:accessRights "PUBLIC" ;
                          dcterms:identifier "RingGasketOuterDiameter" ;
                          skos:definition "The external diameter, which determines the size of the surface it seals against. This dimension is essential for providing a secure seal and preventing leakage."@en ;
                          skos:prefLabel "Diâmetro Externo da Junta de Vedação"@pt-br ,
                                         "Ring Gasket Outer Diameter"@en ;
-                         :hasAttributeScope :InstanceLevelAttribute ,
-                                            :TypeLevelAttribute ;
-                         :hasTypedValue :floatValue ;
-                         :hasValueCardinality :singleValue .
+                         edo:hasAttributeScope edo:InstanceLevelAttribute ,
+                                            edo:TypeLevelAttribute ;
+                         edo:hasTypedValue edo:floatValue ;
+                         edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#RingGasketPressureRating
-:RingGasketPressureRating rdf:type owl:Class ;
-                          rdfs:subClassOf :RingGasketAttribute ;
+edo:RingGasketPressureRating rdf:type owl:Class ;
+                          rdfs:subClassOf edo:RingGasketAttribute ;
                           dcterms:accessRights "PUBLIC" ;
                           dcterms:identifier "RingGasketPressureRating" ;
                           skos:definition "The maximum pressure it can withstand without failing. This rating is important for ensuring that the seal ring performs effectively under the operating pressures of the application."@en ;
                           skos:prefLabel "Classificação de Pressão da Junta de Vedação"@pt-br ,
                                          "Ring Gasket Pressure Rating"@en ;
-                          :hasAttributeScope :InstanceLevelAttribute ,
-                                             :TypeLevelAttribute ;
-                          :hasTypedValue :floatValue ;
-                          :hasValueCardinality :singleValue .
+                          edo:hasAttributeScope edo:InstanceLevelAttribute ,
+                                             edo:TypeLevelAttribute ;
+                          edo:hasTypedValue edo:floatValue ;
+                          edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#RingGasketSpecification
-:RingGasketSpecification rdf:type owl:Class ;
-                         rdfs:subClassOf :RingGasketAttribute ;
+edo:RingGasketSpecification rdf:type owl:Class ;
+                         rdfs:subClassOf edo:RingGasketAttribute ;
                          dcterms:accessRights "PUBLIC" ;
                          dcterms:identifier "RingGasketSpecification" ;
                          skos:definition "The detailed description of it's design and performance characteristics, including material, size, and pressure rating. This provides comprehensive information about the seal ring's suitability for specific applications."@en ;
                          skos:prefLabel "Especificação da Junta de Vedação"@pt-br ,
                                         "Ring Gasket Specification"@en ;
-                         :hasAttributeScope :InstanceLevelAttribute ,
-                                            :TypeLevelAttribute ;
-                         :hasTypedValue :stringValue ;
-                         :hasValueCardinality :singleValue .
+                         edo:hasAttributeScope edo:InstanceLevelAttribute ,
+                                            edo:TypeLevelAttribute ;
+                         edo:hasTypedValue edo:stringValue ;
+                         edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#RingGasketStandard
-:RingGasketStandard rdf:type owl:Class ;
-                    rdfs:subClassOf :RingGasketAttribute ;
+edo:RingGasketStandard rdf:type owl:Class ;
+                    rdfs:subClassOf edo:RingGasketAttribute ;
                     dcterms:accessRights "PUBLIC" ;
                     dcterms:identifier "RingGasketStandard" ;
                     skos:definition "The standard or specification it conforms to, such as API, ISO, or other industry standards. This indicates the compliance of the seal ring with established guidelines for quality and performance."@en ;
                     skos:prefLabel "Padrão da Junta de Vedação"@pt-br ,
                                    "Ring Gasket Standard"@en ;
-                    :hasAttributeScope :InstanceLevelAttribute ,
-                                       :TypeLevelAttribute ;
-                    :hasTypedValue :stringValue ;
-                    :hasValueCardinality :singleValue .
+                    edo:hasAttributeScope edo:InstanceLevelAttribute ,
+                                       edo:TypeLevelAttribute ;
+                    edo:hasTypedValue edo:stringValue ;
+                    edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#RingGasketType
-:RingGasketType rdf:type owl:Class ;
-                rdfs:subClassOf :RingGasketAttribute ;
+edo:RingGasketType rdf:type owl:Class ;
+                rdfs:subClassOf edo:RingGasketAttribute ;
                 dcterms:accessRights "PUBLIC" ;
                 dcterms:identifier "RingGasketType" ;
                 skos:definition "The specific type or design. This classification helps identify the appropriate seal ring based on its design and application requirements, ensuring it meets the sealing needs under various conditions."@en ;
                 skos:prefLabel "Ring Gasket Type"@en ,
                                "Tipo de Junta de Vedação"@pt-br ;
-                :hasAttributeScope :InstanceLevelAttribute ,
-                                   :TypeLevelAttribute ;
-                :hasTypedValue :stringValue ;
-                :hasValueCardinality :singleValue .
+                edo:hasAttributeScope edo:InstanceLevelAttribute ,
+                                   edo:TypeLevelAttribute ;
+                edo:hasTypedValue edo:stringValue ;
+                edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#RiserBalcony
-:RiserBalcony rdf:type owl:Class ;
-              rdfs:subClassOf :Location ;
+edo:RiserBalcony rdf:type owl:Class ;
+              rdfs:subClassOf edo:Location ;
               dcterms:identifier "RiserBalcony" ;
               skos:definition "Installation location for supports and accessories on the riser balcony of the production unit."@en ;
               skos:prefLabel "Plataforma do Riser"@pt-br ,
@@ -5316,51 +5315,51 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#RiserConfiguration
-:RiserConfiguration rdf:type owl:Class ;
-                    rdfs:subClassOf :DomainAttribute ;
+edo:RiserConfiguration rdf:type owl:Class ;
+                    rdfs:subClassOf edo:DomainAttribute ;
                     dcterms:accessRights "PUBLIC" ;
                     dcterms:identifier "RiserConfiguration" ;
                     skos:definition "This property specifies the configuration type for the riser section of the pipeline. It provides key information on the structural design, indicating the arrangement and dynamic behaviour of the riser system. The chosen configuration affects how the structure responds to environmental forces, such as currents and pressure, and plays a critical role in determining the overall performance and durability of the system."@en ;
                     skos:prefLabel "Configuração do Riser"@pt-br ,
                                    "Riser Configuration"@en ;
-                    :hasAttributeScope :InstanceLevelAttribute ;
-                    :hasTypedValue :stringValue ;
-                    :hasValueCardinality :singleValue .
+                    edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                    edo:hasTypedValue edo:stringValue ;
+                    edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#RiserSpan
-:RiserSpan rdf:type owl:Class ;
-           rdfs:subClassOf :PipelineSpan ;
+edo:RiserSpan rdf:type owl:Class ;
+           rdfs:subClassOf edo:PipelineSpan ;
            dcterms:identifier "RiserSpan" .
 
 
 ###  https://w3id.org/energy-domain/edo#RiserSupport
-:RiserSupport rdf:type owl:Class ;
-              rdfs:subClassOf :Component ;
+edo:RiserSupport rdf:type owl:Class ;
+              rdfs:subClassOf edo:Component ;
               dcterms:identifier "RiserSupport" .
 
 
 ###  https://w3id.org/energy-domain/edo#RiserSupportBuoy
-:RiserSupportBuoy rdf:type owl:Class ;
-                  rdfs:subClassOf :BuoyancyTank ;
+edo:RiserSupportBuoy rdf:type owl:Class ;
+                  rdfs:subClassOf edo:BuoyancyTank ;
                   dcterms:identifier "RiserSupportBuoy" .
 
 
 ###  https://w3id.org/energy-domain/edo#RoboticActuator
-:RoboticActuator rdf:type owl:Class ;
-                 rdfs:subClassOf :AuxiliaryModule ;
+edo:RoboticActuator rdf:type owl:Class ;
+                 rdfs:subClassOf edo:AuxiliaryModule ;
                  dcterms:identifier "RoboticActuator" .
 
 
 ###  https://w3id.org/energy-domain/edo#RopeSegment
-:RopeSegment rdf:type owl:Class ;
-             rdfs:subClassOf :LinearObject ;
+edo:RopeSegment rdf:type owl:Class ;
+             rdfs:subClassOf edo:LinearObject ;
              dcterms:identifier "RopeSegment" .
 
 
 ###  https://w3id.org/energy-domain/edo#RotatingEquipmentEngineering
-:RotatingEquipmentEngineering rdf:type owl:Class ;
-                              rdfs:subClassOf :EquipmentEngineering ;
+edo:RotatingEquipmentEngineering rdf:type owl:Class ;
+                              rdfs:subClassOf edo:EquipmentEngineering ;
                               rdfs:label "Engenharia de Equipamentos Rotativos"@pt-br ,
                                          "Rotating Equipment Engineering"@en ;
                               skos:definition "Engenharia de equipamentos mecânicos com componentes rotativos como bombas, compressores e turbinas."@pt-br ,
@@ -5368,102 +5367,102 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#RotatingMachine
-:RotatingMachine rdf:type owl:Class ;
-                 rdfs:subClassOf :PowerMachine ;
+edo:RotatingMachine rdf:type owl:Class ;
+                 rdfs:subClassOf edo:PowerMachine ;
                  dcterms:identifier "RotatingMachine" .
 
 
 ###  https://w3id.org/energy-domain/edo#RunningTool
-:RunningTool rdf:type owl:Class ;
-             rdfs:subClassOf :ActuatedEquipment ;
+edo:RunningTool rdf:type owl:Class ;
+             rdfs:subClassOf edo:ActuatedEquipment ;
              dcterms:identifier "RunningTool" .
 
 
 ###  https://w3id.org/energy-domain/edo#RuptDefAlongFibers
-:RuptDefAlongFibers rdf:type owl:Class ;
-                    rdfs:subClassOf :DomainAttribute ;
+edo:RuptDefAlongFibers rdf:type owl:Class ;
+                    rdfs:subClassOf edo:DomainAttribute ;
                     dcterms:accessRights "PUBLIC" ;
                     dcterms:identifier "RuptDefAlongFibers" ;
                     skos:definition "Describes the deformation that occurs when the composite material ruptures in a direction parallel to its fibers. This property is essential for assessing the material's behavior under stress aligned with the fiber orientation, providing insights into its performance and durability in subsea structures where axial forces are present."@en ;
                     skos:prefLabel "Deformação de Ruptura longitudinalmente às fibras"@pt-br ,
                                    "Rupture Deformation Along Fibers"@en ;
-                    :hasAttributeScope :TypeLevelAttribute ;
-                    :hasTypedValue :floatValue ;
-                    :hasValueCardinality :singleValue .
+                    edo:hasAttributeScope edo:TypeLevelAttribute ;
+                    edo:hasTypedValue edo:floatValue ;
+                    edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#RuptDefPerpendFibers
-:RuptDefPerpendFibers rdf:type owl:Class ;
-                      rdfs:subClassOf :DomainAttribute ;
+edo:RuptDefPerpendFibers rdf:type owl:Class ;
+                      rdfs:subClassOf edo:DomainAttribute ;
                       dcterms:accessRights "PUBLIC" ;
                       dcterms:identifier "RuptDefPerpendFibers" ;
                       skos:definition "Describes the deformation that occurs when the composite material ruptures in a direction perpendicular to its fibers. This property is crucial for understanding the material's behavior under stress conditions that do not align with the fiber orientation, helping to assess its performance and failure limits in subsea structures."@en ;
                       skos:prefLabel "Deformação de Ruptura perpendicularmente às fibras"@pt-br ,
                                      "Rupture Deformation Perpendicular To Fibers"@en ;
-                      :hasAttributeScope :TypeLevelAttribute ;
-                      :hasTypedValue :floatValue ;
-                      :hasValueCardinality :singleValue .
+                      edo:hasAttributeScope edo:TypeLevelAttribute ;
+                      edo:hasTypedValue edo:floatValue ;
+                      edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#SCM
-:SCM rdf:type owl:Class ;
-     rdfs:subClassOf :AuxiliaryModule ;
+edo:SCM rdf:type owl:Class ;
+     rdfs:subClassOf edo:AuxiliaryModule ;
      dcterms:identifier "SCM" .
 
 
 ###  https://w3id.org/energy-domain/edo#SCMMB
-:SCMMB rdf:type owl:Class ;
-       rdfs:subClassOf :AuxiliaryModule ;
+edo:SCMMB rdf:type owl:Class ;
+       rdfs:subClassOf edo:AuxiliaryModule ;
        dcterms:identifier "SCMMB" .
 
 
 ###  https://w3id.org/energy-domain/edo#SCMRunningTool
-:SCMRunningTool rdf:type owl:Class ;
-                rdfs:subClassOf :RunningTool ;
+edo:SCMRunningTool rdf:type owl:Class ;
+                rdfs:subClassOf edo:RunningTool ;
                 dcterms:identifier "SCMRunningTool" .
 
 
 ###  https://w3id.org/energy-domain/edo#SDU
-:SDU rdf:type owl:Class ;
-     rdfs:subClassOf :SubseaEquipment ;
+edo:SDU rdf:type owl:Class ;
+     rdfs:subClassOf edo:SubseaEquipment ;
      dcterms:identifier "SDU" .
 
 
 ###  https://w3id.org/energy-domain/edo#SEM
-:SEM rdf:type owl:Class ;
-     rdfs:subClassOf :ElectronicDevice ;
+edo:SEM rdf:type owl:Class ;
+     rdfs:subClassOf edo:ElectronicDevice ;
      dcterms:identifier "SEM" .
 
 
 ###  https://w3id.org/energy-domain/edo#SacrificialSheath
-:SacrificialSheath rdf:type owl:Class ;
-                   rdfs:subClassOf :SolidLayer ;
+edo:SacrificialSheath rdf:type owl:Class ;
+                   rdfs:subClassOf edo:SolidLayer ;
                    dcterms:identifier "SacrificialSheath" ;
                    skos:definition "A protective layer in subsea flexible pipes designed to absorb damage from external environmental factors, such as abrasion or impact, over time. The Sacrificial Sheath is intended to wear out or degrade under harsh conditions, thereby preserving the integrity of the underlying layers and prolonging the overall lifespan of the pipe. Made from durable materials, this sheath acts as the first line of defense, allowing for the controlled degradation of the pipe's outer surface without affecting its core structural or functional performance."@en ;
                    skos:prefLabel "Camada de Sacrifício"@pt-br ,
                                   "Sacrificial Sheath"@en ;
-                   :ifc_equivalentClass "IfcPipeSegment" ;
-                   :ifc_objectType "SacrificialSheath" ;
-                   :ifc_predefinedType "USERDEFINED" .
+                   edo:ifc_equivalentClass "IfcPipeSegment" ;
+                   edo:ifc_objectType "SacrificialSheath" ;
+                   edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#SafeWorkingLoad
-:SafeWorkingLoad rdf:type owl:Class ;
-                 rdfs:subClassOf :DomainAttribute ;
+edo:SafeWorkingLoad rdf:type owl:Class ;
+                 rdfs:subClassOf edo:DomainAttribute ;
                  dcterms:accessRights "PUBLIC" ;
                  dcterms:identifier "SafeWorkingLoad" ;
                  skos:definition "Safe Working Load (SWL) refers to the maximum load that can be safely handled under normal operating conditions. This value ensures the equipment operates within its designed capacity, preventing overloading and potential failure."@en ;
                  skos:prefLabel "Carga Máxima Segura de Trabalho"@pt-br ,
                                 "Safe Working Load"@en ;
-                 :hasAttributeScope :InstanceLevelAttribute ,
-                                    :TypeLevelAttribute ;
-                 :hasTypedValue :floatValue ;
-                 :hasValueCardinality :singleValue .
+                 edo:hasAttributeScope edo:InstanceLevelAttribute ,
+                                    edo:TypeLevelAttribute ;
+                 edo:hasTypedValue edo:floatValue ;
+                 edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#SafetyLossPreventionEngineering
-:SafetyLossPreventionEngineering rdf:type owl:Class ;
-                                 rdfs:subClassOf :TechnicalDiscipline ;
+edo:SafetyLossPreventionEngineering rdf:type owl:Class ;
+                                 rdfs:subClassOf edo:TechnicalDiscipline ;
                                  rdfs:label "Engenharia de Segurança e Prevenção de Perdas"@pt-br ,
                                             "Safety & Loss Prevention Engineering"@en ;
                                  skos:definition "Disciplina de engenharia focada em avaliação de riscos, sistemas de segurança e prevenção de perdas."@pt-br ,
@@ -5471,53 +5470,53 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#SandDetector
-:SandDetector rdf:type owl:Class ;
-              rdfs:subClassOf :Sensor ;
+edo:SandDetector rdf:type owl:Class ;
+              rdfs:subClassOf edo:Sensor ;
               dcterms:identifier "SandDetector" .
 
 
 ###  https://w3id.org/energy-domain/edo#Sensor
-:Sensor rdf:type owl:Class ;
-        rdfs:subClassOf :ElectronicDevice ;
+edo:Sensor rdf:type owl:Class ;
+        rdfs:subClassOf edo:ElectronicDevice ;
         dcterms:identifier "Sensor" .
 
 
 ###  https://w3id.org/energy-domain/edo#SeparatorVessel
-:SeparatorVessel rdf:type owl:Class ;
-                 rdfs:subClassOf :Vessel ;
+edo:SeparatorVessel rdf:type owl:Class ;
+                 rdfs:subClassOf edo:Vessel ;
                  dcterms:identifier "SeparatorVessel" .
 
 
 ###  https://w3id.org/energy-domain/edo#SerialNumber
-:SerialNumber rdf:type owl:Class ;
-              rdfs:subClassOf :DomainAttribute ;
+edo:SerialNumber rdf:type owl:Class ;
+              rdfs:subClassOf edo:DomainAttribute ;
               dcterms:accessRights "PUBLIC" ;
               dcterms:identifier "SerialNumber" ;
               skos:definition "A unique identifier assigned to each individual item, distinguishing it from all other units of the same type. The Serial Number is critical for traceability, maintenance, and warranty purposes, ensuring that the history, performance, and lifecycle of the equipment can be tracked. It is often used in conjunction with a Part Number, which identifies the type or model of the component."@en ;
               skos:prefLabel "Número de Série"@pt-br ,
                              "Serial Number"@en ;
-              :hasAttributeScope :InstanceLevelAttribute ;
-              :hasTypedValue :stringValue ;
-              :hasValueCardinality :singleValue .
+              edo:hasAttributeScope edo:InstanceLevelAttribute ;
+              edo:hasTypedValue edo:stringValue ;
+              edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#Service
-:Service rdf:type owl:Class ;
-         rdfs:subClassOf :DomainAttribute ;
+edo:Service rdf:type owl:Class ;
+         rdfs:subClassOf edo:DomainAttribute ;
          dcterms:accessRights "PUBLIC" ;
          dcterms:identifier "Service" ;
          skos:definition "Escolha um da lista: IA (Injeção de água); IG (Injeção de Gás); LPO (Linha de Produção de Óleo); PG (Produtor de Gás); SE (Serviço); GAS (Gasoduto); UEH (Umbilical Eletro Hidráulico); CEP (Cabo Elétrico de Potência)"@pt-br ,
                          "Indicates the type of service the pipeline is designated for, specifying its operational purpose within the project. This classification is used to ensure proper management, installation, and use of the pipeline according to its intended function."@en ;
          skos:prefLabel "Service"@en ,
                         "Serviço"@pt-br ;
-         :hasAttributeScope :InstanceLevelAttribute ;
-         :hasTypedValue :stringValue ;
-         :hasValueCardinality :singleValue .
+         edo:hasAttributeScope edo:InstanceLevelAttribute ;
+         edo:hasTypedValue edo:stringValue ;
+         edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#Shackle
-:Shackle rdf:type owl:Class ;
-         rdfs:subClassOf :MooringAccessory ;
+edo:Shackle rdf:type owl:Class ;
+         rdfs:subClassOf edo:MooringAccessory ;
          dcterms:identifier "Shackle" ;
          skos:altLabel "Anchor Shackle"@en ,
                        "Bow Shackle"@en ,
@@ -5527,111 +5526,111 @@ rdf:value rdf:type owl:DatatypeProperty .
          skos:definition "A device used to connect and secure components in subsea systems, particularly during lifting, handling, or mooring operations. The Shackle typically consists of a U-shaped metal piece with a removable pin or bolt, allowing it to link components such as chains, slings, or cables. It provides a strong and reliable connection point, ensuring that loads can be safely transferred or lifted without risk of detachment or failure. Shackles are essential for securing flexible lines and other equipment during installation and maintenance in subsea environments."@en ;
          skos:prefLabel "Manilha"@pt-br ,
                         "Shackle"@en ;
-         :hasAttribute :ShackleInnerDiameter ,
-                       :ShackleOpeningWidth ,
-                       :ShackleOuterDiameter ,
-                       :ShackleThickness ,
-                       :WorkingLoadLimit ;
-         :ifc_equivalentClass "IfcMechanicalFastener" ;
-         :ifc_objectType "Shackle" ;
-         :ifc_predefinedType "USERDEFINED" .
+         edo:hasAttribute edo:ShackleInnerDiameter ,
+                       edo:ShackleOpeningWidth ,
+                       edo:ShackleOuterDiameter ,
+                       edo:ShackleThickness ,
+                       edo:WorkingLoadLimit ;
+         edo:ifc_equivalentClass "IfcMechanicalFastener" ;
+         edo:ifc_objectType "Shackle" ;
+         edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#ShackleInnerDiameter
-:ShackleInnerDiameter rdf:type owl:Class ;
-                      rdfs:subClassOf :DomainAttribute ;
+edo:ShackleInnerDiameter rdf:type owl:Class ;
+                      rdfs:subClassOf edo:DomainAttribute ;
                       dcterms:accessRights "PUBLIC" ;
                       dcterms:identifier "ShackleInnerDiameter" ;
                       skos:definition "Indicates the inner diameter of the shackle. This property measures the width of the space inside the shackle, which is important for ensuring compatibility with other components and for determining the appropriate fit and load distribution."@en ;
                       skos:prefLabel "Diâmetro interno da furação do olhal"@pt-br ,
                                      "Shackle Inner Diameter"@en ;
-                      :hasAttributeScope :InstanceLevelAttribute ;
-                      :hasTypedValue :floatValue ;
-                      :hasValueCardinality :singleValue .
+                      edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                      edo:hasTypedValue edo:floatValue ;
+                      edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#ShackleOpeningWidth
-:ShackleOpeningWidth rdf:type owl:Class ;
-                     rdfs:subClassOf :DomainAttribute ;
+edo:ShackleOpeningWidth rdf:type owl:Class ;
+                     rdfs:subClassOf edo:DomainAttribute ;
                      dcterms:accessRights "PUBLIC" ;
                      dcterms:identifier "ShackleOpeningWidth" ;
                      skos:definition "Measures the width of the opening in the shackle where components, such as pins or cables, are inserted. This property is crucial for ensuring that the shackle can properly accommodate and secure the intended connecting elements."@en ;
                      skos:prefLabel "Largura da Abertura"@pt-br ,
                                     "Shackle Opening Width"@en ;
-                     :hasAttributeScope :InstanceLevelAttribute ;
-                     :hasTypedValue :floatValue ;
-                     :hasValueCardinality :singleValue .
+                     edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                     edo:hasTypedValue edo:floatValue ;
+                     edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#ShackleOuterDiameter
-:ShackleOuterDiameter rdf:type owl:Class ;
-                      rdfs:subClassOf :DomainAttribute ;
+edo:ShackleOuterDiameter rdf:type owl:Class ;
+                      rdfs:subClassOf edo:DomainAttribute ;
                       dcterms:accessRights "PUBLIC" ;
                       dcterms:identifier "ShackleOuterDiameter" ;
                       skos:definition "Indicates the outer diameter of the shackle. This property provides the measurement of the overall width of the shackle, which is crucial for ensuring it fits properly with other components and meets the design specifications for load-bearing and connection requirements."@en ;
                       skos:prefLabel "Diâmetro externo do olhal"@pt-br ,
                                      "Shackle Outer Diameter"@en ;
-                      :hasAttributeScope :InstanceLevelAttribute ;
-                      :hasTypedValue :floatValue ;
-                      :hasValueCardinality :singleValue .
+                      edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                      edo:hasTypedValue edo:floatValue ;
+                      edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#ShackleThickness
-:ShackleThickness rdf:type owl:Class ;
-                  rdfs:subClassOf :DomainAttribute ;
+edo:ShackleThickness rdf:type owl:Class ;
+                  rdfs:subClassOf edo:DomainAttribute ;
                   dcterms:accessRights "PUBLIC" ;
                   dcterms:identifier "ShackleThickness" ;
                   skos:definition "Specifies the thickness of the shackle material. This property measures the distance between the inner and outer surfaces of the shackle, which is essential for understanding its strength, durability, and ability to handle load stresses."@en ;
                   skos:prefLabel "Espessura do olhal"@pt-br ,
                                  "Shackle Thickness"@en ;
-                  :hasAttributeScope :InstanceLevelAttribute ;
-                  :hasTypedValue :floatValue ;
-                  :hasValueCardinality :singleValue .
+                  edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                  edo:hasTypedValue edo:floatValue ;
+                  edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#ShearableRiserJoint
-:ShearableRiserJoint rdf:type owl:Class ;
-                     rdfs:subClassOf :RunningTool ;
+edo:ShearableRiserJoint rdf:type owl:Class ;
+                     rdfs:subClassOf edo:RunningTool ;
                      dcterms:identifier "ShearableRiserJoint" .
 
 
 ###  https://w3id.org/energy-domain/edo#ShortTermFloatDensity
-:ShortTermFloatDensity rdf:type owl:Class ;
-                       rdfs:subClassOf :DomainAttribute ;
+edo:ShortTermFloatDensity rdf:type owl:Class ;
+                       rdfs:subClassOf edo:DomainAttribute ;
                        dcterms:accessRights "PUBLIC" ;
                        dcterms:identifier "ShortTermFloatDensity" ;
                        skos:definition "Representa a densidade do flutuador logo após o início da operação, considerando um aumento de densidade devido à absorção de água em pequena quantidade ou outras alterações superficiais."@pt-br ,
                                        "The density of the float material in the early stages of operation, accounting for slight water absorption or other surface-level changes."@en ;
                        skos:prefLabel "Densidade do Flutuador a Curto Prazo"@pt-br ,
                                       "Short Term Float Density"@en ;
-                       :hasAttributeScope :TypeLevelAttribute ;
-                       :hasTypedValue :floatValue ;
-                       :hasValueCardinality :singleValue .
+                       edo:hasAttributeScope edo:TypeLevelAttribute ;
+                       edo:hasTypedValue edo:floatValue ;
+                       edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#ShortTermFloatVolume
-:ShortTermFloatVolume rdf:type owl:Class ;
-                      rdfs:subClassOf :DomainAttribute ;
+edo:ShortTermFloatVolume rdf:type owl:Class ;
+                      rdfs:subClassOf edo:DomainAttribute ;
                       dcterms:accessRights "PUBLIC" ;
                       dcterms:identifier "ShortTermFloatVolume" ;
                       skos:definition "O volume submerso esperado logo após o início da operação, levando em consideração pequenas variações iniciais, como a absorção mínima de água ou pequenas deformações. Serve para calcular a flutuabilidade em condições reais no curto prazo."@pt-br ,
                                       "The expected submerged volume of the float during the initial phase of operation, considering minor factors like slight water absorption or small deformations."@en ;
                       skos:prefLabel "Short Term Float Volume"@en ,
                                      "Volume do Flutuador a Curto Prazo"@pt-br ;
-                      :hasAttributeScope :TypeLevelAttribute ;
-                      :hasTypedValue :floatValue ;
-                      :hasValueCardinality :singleValue .
+                      edo:hasAttributeScope edo:TypeLevelAttribute ;
+                      edo:hasTypedValue edo:floatValue ;
+                      edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#Socket
-:Socket rdf:type owl:Class ;
-        rdfs:subClassOf :MooringAccessory ;
+edo:Socket rdf:type owl:Class ;
+        rdfs:subClassOf edo:MooringAccessory ;
         dcterms:identifier "Socket" .
 
 
 ###  https://w3id.org/energy-domain/edo#Solar
-:Solar rdf:type owl:Class ;
-       rdfs:subClassOf :Renewable ;
+edo:Solar rdf:type owl:Class ;
+       rdfs:subClassOf edo:Renewable ;
        rdfs:label "Energia Solar"@pt-br ,
                   "Solar Energy"@en ;
        skos:definition "Energia obtida da luz solar, incluindo sistemas fotovoltaicos e térmicos."@pt-br ,
@@ -5639,8 +5638,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#SolidLayer
-:SolidLayer rdf:type owl:Class ;
-            rdfs:subClassOf :FlexibleStructureLayer ;
+edo:SolidLayer rdf:type owl:Class ;
+            rdfs:subClassOf edo:FlexibleStructureLayer ;
             dcterms:identifier "SolidLayer" ;
             skos:definition "Camada maciça formada por extrusão contínua de um material"@pt-br ,
                             "Continuous layer used in subsea flexible pipes or similar structures, typically fabricated through extrusion. It provides structural reinforcement, pressure containment, or environmental protection, ensuring the integrity and performance of the pipe by offering consistent support or shielding."@en ;
@@ -5649,156 +5648,156 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#SolubilityTable
-:SolubilityTable rdf:type owl:Class ;
-                 rdfs:subClassOf :DomainAttribute ;
+edo:SolubilityTable rdf:type owl:Class ;
+                 rdfs:subClassOf edo:DomainAttribute ;
                  dcterms:accessRights "PUBLIC" ;
                  dcterms:identifier "SolubilityTable" ;
                  skos:definition "Provides data on the solubility of various substances in a material, used to evaluate how different fluids or gases dissolve into the structure. This information is essential for assessing material compatibility and predicting the effects of prolonged exposure to specific substances under operational conditions."@en ;
                  skos:prefLabel "Solubility Table (Specific for Polymeric Materials)"@en ,
                                 "Tabela de Solubilidade (Específica para Materiais Poliméricos)"@pt-br ;
-                 :hasAttributeScope :TypeLevelAttribute .
+                 edo:hasAttributeScope edo:TypeLevelAttribute .
 
 
 ###  https://w3id.org/energy-domain/edo#SolubilityTable_MoleculeIdentifier
-:SolubilityTable_MoleculeIdentifier rdf:type owl:Class ;
-                                    rdfs:subClassOf :SolubilityTable ;
+edo:SolubilityTable_MoleculeIdentifier rdf:type owl:Class ;
+                                    rdfs:subClassOf edo:SolubilityTable ;
                                     dcterms:accessRights "PUBLIC" ;
                                     dcterms:identifier "SolubilityTable_MoleculeIdentifier" ;
                                     skos:definition "Specifies the type of molecule. This property identifies the particular molecule involved, which is crucial for understanding the material's interaction with or response to different chemical substances."@en ,
                                                     "Tipo de Molécula (co2, h2s, ch4, h2o,…)"@pt-br ;
                                     skos:prefLabel "Identificador de Molécula"@pt-br ,
                                                    "Molecule Identifier"@en ;
-                                    :hasAttributeScope :TypeLevelAttribute ;
-                                    :hasTypedValue :stringValue ;
-                                    :hasValueCardinality :multiValue .
+                                    edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                    edo:hasTypedValue edo:stringValue ;
+                                    edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#SolubilityTable_PolymerState
-:SolubilityTable_PolymerState rdf:type owl:Class ;
-                              rdfs:subClassOf :SolubilityTable ;
+edo:SolubilityTable_PolymerState rdf:type owl:Class ;
+                              rdfs:subClassOf edo:SolubilityTable ;
                               dcterms:accessRights "PUBLIC" ;
                               dcterms:identifier "SolubilityTable_PolymerState" ;
                               skos:definition "The state of the polymeric material is specified.. This property is crucial for understanding how the material behaves under different conditions and its suitability for various applications."@en ;
                               skos:prefLabel "Estado do Polímero"@pt-br ,
                                              "Polymer State"@en ;
-                              :hasAttributeScope :TypeLevelAttribute ;
-                              :hasTypedValue :stringValue ;
-                              :hasValueCardinality :multiValue .
+                              edo:hasAttributeScope edo:TypeLevelAttribute ;
+                              edo:hasTypedValue edo:stringValue ;
+                              edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#SolubilityTable_SolubilityCoefficient
-:SolubilityTable_SolubilityCoefficient rdf:type owl:Class ;
-                                       rdfs:subClassOf :SolubilityTable ;
+edo:SolubilityTable_SolubilityCoefficient rdf:type owl:Class ;
+                                       rdfs:subClassOf edo:SolubilityTable ;
                                        dcterms:accessRights "PUBLIC" ;
                                        dcterms:identifier "SolubilityTable_SolubilityCoefficient" ;
                                        skos:definition "Represents the rate at which a substance dissolves in a specific material, indicating how much of the substance can be absorbed by the material. This property is important for understanding the material's chemical compatibility and behavior when exposed to various substances."@en ;
                                        skos:prefLabel "Coeficiente de solubilidade"@pt-br ,
                                                       "Solubility Coefficient"@en ;
-                                       :hasAttributeScope :TypeLevelAttribute ;
-                                       :hasTypedValue :floatValue ;
-                                       :hasValueCardinality :multiValue .
+                                       edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                       edo:hasTypedValue edo:floatValue ;
+                                       edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#SolubilityTable_Temperature
-:SolubilityTable_Temperature rdf:type owl:Class ;
-                             rdfs:subClassOf :SolubilityTable ;
+edo:SolubilityTable_Temperature rdf:type owl:Class ;
+                             rdfs:subClassOf edo:SolubilityTable ;
                              dcterms:accessRights "PUBLIC" ;
                              dcterms:identifier "SolubilityTable_Temperature" ;
                              skos:definition "Represents the thermal condition or measurement of heat for a component or system. This property is important for assessing how the component performs or operates under specific thermal conditions, ensuring it remains within safe and effective operating limits."@en ;
                              skos:prefLabel "Temperatura"@pt-br ,
                                             "Temperature"@en ;
-                             :hasAttributeScope :TypeLevelAttribute ;
-                             :hasTypedValue :floatValue ;
-                             :hasValueCardinality :multiValue .
+                             edo:hasAttributeScope edo:TypeLevelAttribute ;
+                             edo:hasTypedValue edo:floatValue ;
+                             edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#SpareQuantity
-:SpareQuantity rdf:type owl:Class ;
-               rdfs:subClassOf :DomainAttribute ;
+edo:SpareQuantity rdf:type owl:Class ;
+               rdfs:subClassOf edo:DomainAttribute ;
                dcterms:accessRights "PUBLIC" ;
                dcterms:identifier "SpareQuantity" ;
                skos:definition "Specifies the number of spare units available, ensuring adequate backup components are on hand for maintenance or replacement. This quantity helps in planning and minimizing downtime during operations."@en ;
                skos:prefLabel "Quantidade de Sobressalentes"@pt-br ,
                               "Spare Quantity"@en ;
-               :hasAttributeScope :InstanceLevelAttribute ;
-               :hasTypedValue :intValue ;
-               :hasValueCardinality :singleValue .
+               edo:hasAttributeScope edo:InstanceLevelAttribute ;
+               edo:hasTypedValue edo:intValue ;
+               edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#SpecialRequirements
-:SpecialRequirements rdf:type owl:Class ;
-                     rdfs:subClassOf :DomainAttribute ;
+edo:SpecialRequirements rdf:type owl:Class ;
+                     rdfs:subClassOf edo:DomainAttribute ;
                      dcterms:accessRights "PUBLIC" ;
                      dcterms:identifier "SpecialRequirements" ;
                      skos:definition "Requisitos especiais, Observações ou Documentos especiais para o tramo"@pt-br ,
                                      "Special requirements refer to specific conditions, standards, or instructions that must be met during the design, manufacturing, installation, or operation of an object or system. These can include unique technical specifications, safety measures, regulatory compliance, or client-specific requests that go beyond standard procedures."@en ;
                      skos:prefLabel "Requisitos Especiais"@pt-br ,
                                     "Special Requirements"@en ;
-                     :hasAttributeScope :InstanceLevelAttribute ;
-                     :hasTypedValue :stringValue ;
-                     :hasValueCardinality :singleValue .
+                     edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                     edo:hasTypedValue edo:stringValue ;
+                     edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#SpecificHeatCapacity
-:SpecificHeatCapacity rdf:type owl:Class ;
-                      rdfs:subClassOf :DomainAttribute ;
+edo:SpecificHeatCapacity rdf:type owl:Class ;
+                      rdfs:subClassOf edo:DomainAttribute ;
                       dcterms:accessRights "PUBLIC" ;
                       dcterms:identifier "SpecificHeatCapacity" ;
                       skos:definition "Calor Específico do material"@pt-br ,
                                       "Indicates the amount of heat required to raise the temperature of the material by a specific amount, typically measured per unit mass. This property is important for understanding the thermal behavior of the material.."@en ;
                       skos:prefLabel "Calor Específico"@pt-br ,
                                      "Specific Heat Capacity"@en ;
-                      :hasAttributeScope :TypeLevelAttribute ;
-                      :hasTypedValue :floatValue ;
-                      :hasValueCardinality :singleValue .
+                      edo:hasAttributeScope edo:TypeLevelAttribute ;
+                      edo:hasTypedValue edo:floatValue ;
+                      edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#SpecificWeight
-:SpecificWeight rdf:type owl:Class ;
-                rdfs:subClassOf :DomainAttribute ;
+edo:SpecificWeight rdf:type owl:Class ;
+                rdfs:subClassOf edo:DomainAttribute ;
                 dcterms:accessRights "PUBLIC" ;
                 dcterms:identifier "SpecificWeight" ;
                 skos:definition "Indicates the weight of the material per unit volume. This property is crucial for understanding the material's density and its impact on the overall weight."@en ,
                                 "Peso específico do material"@pt-br ;
                 skos:prefLabel "Peso Específico"@pt-br ,
                                "Specific Weight"@en ;
-                :hasAttributeScope :TypeLevelAttribute ;
-                :hasTypedValue :floatValue ;
-                :hasValueCardinality :singleValue .
+                edo:hasAttributeScope edo:TypeLevelAttribute ;
+                edo:hasTypedValue edo:floatValue ;
+                edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#SpliceBox
-:SpliceBox rdf:type owl:Class ;
-           rdfs:subClassOf :ComponentDevice ;
+edo:SpliceBox rdf:type owl:Class ;
+           rdfs:subClassOf edo:ComponentDevice ;
            dcterms:identifier "SpliceBox" .
 
 
 ###  https://w3id.org/energy-domain/edo#SplitCollar
-:SplitCollar rdf:type owl:Class ;
-             rdfs:subClassOf :LineAncillary ;
+edo:SplitCollar rdf:type owl:Class ;
+             rdfs:subClassOf edo:LineAncillary ;
              dcterms:identifier "SplitCollar" ;
              skos:definition "A component used to encircle and secure parts of subsea systems, such as flexible pipes, risers, or accessories. The Split Collar is designed with a split or gap, allowing it to be clamped around the pipe or component and then fastened together. This design facilitates easy installation and removal, making it useful for applications where adjustments or maintenance are required. The Split Collar provides structural support, alignment, and stability, ensuring that the connected components remain securely in place."@en ;
              skos:prefLabel "Colar Bipartido"@pt-br ,
                             "Split Collar"@en ;
-             :hasAttribute :PipeMountPosition .
+             edo:hasAttribute edo:PipeMountPosition .
 
 
 ###  https://w3id.org/energy-domain/edo#SpoolingTension
-:SpoolingTension rdf:type owl:Class ;
-                 rdfs:subClassOf :DomainAttribute ;
+edo:SpoolingTension rdf:type owl:Class ;
+                 rdfs:subClassOf edo:DomainAttribute ;
                  dcterms:accessRights "PUBLIC" ;
                  dcterms:identifier "SpoolingTension" ;
                  skos:definition "Represents the tension applied to a flexible component during the spooling process. This property is crucial for ensuring that the material is wound onto the reel or spool without exceeding its mechanical limits, preventing damage or deformation during handling and storage."@en ;
                  skos:prefLabel "Spooling Tension"@en ,
                                 "Tração de Desenrolamento"@pt-br ;
-                 :hasAttributeScope :TypeLevelAttribute ;
-                 :hasTypedValue :floatValue ;
-                 :hasValueCardinality :singleValue .
+                 edo:hasAttributeScope edo:TypeLevelAttribute ;
+                 edo:hasTypedValue edo:floatValue ;
+                 edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#StaticEquipmentEngineering
-:StaticEquipmentEngineering rdf:type owl:Class ;
-                            rdfs:subClassOf :EquipmentEngineering ;
+edo:StaticEquipmentEngineering rdf:type owl:Class ;
+                            rdfs:subClassOf edo:EquipmentEngineering ;
                             rdfs:label "Engenharia de Equipamentos Estáticos"@pt-br ,
                                        "Static Equipment Engineering"@en ;
                             skos:definition "Engenharia de equipamentos industriais sem partes móveis como vasos de pressão, tanques e trocadores de calor."@pt-br ,
@@ -5806,15 +5805,15 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#StaticUmbilicalSpan
-:StaticUmbilicalSpan rdf:type owl:Class ;
-                     rdfs:subClassOf :UmbilicalSpan ;
+edo:StaticUmbilicalSpan rdf:type owl:Class ;
+                     rdfs:subClassOf edo:UmbilicalSpan ;
                      dcterms:identifier "StaticUmbilicalSpan" .
 
 
 ###  https://w3id.org/energy-domain/edo#StatusAttribute
-:StatusAttribute rdf:type owl:Class ;
-                 rdfs:subClassOf :AttributeDomainCategory ,
-                                 :DomainAttribute ;
+edo:StatusAttribute rdf:type owl:Class ;
+                 rdfs:subClassOf edo:AttributeDomainCategory ,
+                                 edo:DomainAttribute ;
                  rdfs:comment "Represents operational state, availability, or maintenance condition."@en ;
                  rdfs:label "Atributo de Status"@pt-br ,
                             "Status Attribute"@en ;
@@ -5823,22 +5822,22 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#StiffTorsionalStiffnessAtSeaLevel
-:StiffTorsionalStiffnessAtSeaLevel rdf:type owl:Class ;
-                                   rdfs:subClassOf :DomainAttribute ;
+edo:StiffTorsionalStiffnessAtSeaLevel rdf:type owl:Class ;
+                                   rdfs:subClassOf edo:DomainAttribute ;
                                    dcterms:accessRights "PUBLIC" ;
                                    dcterms:identifier "StiffTorsionalStiffnessAtSeaLevel" ;
                                    skos:definition "Represents the torsional stiffness of a component when measured at sea level, indicating its resistance to twisting under applied torque. This property is important for ensuring that the component maintains its structural integrity and performance under rotational forces."@en ,
                                                    "Rigidez a torção (GJ) (maior valor) a 20°C e pressão atmosferica (dentro e fora)"@pt-br ;
                                    skos:prefLabel "Rigidez a Torção Rígida ao Nível do Mar"@pt-br ,
                                                   "Stiff Torsional Stiffness At Sea Level"@en ;
-                                   :hasAttributeScope :TypeLevelAttribute ;
-                                   :hasTypedValue :floatValue ;
-                                   :hasValueCardinality :singleValue .
+                                   edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                   edo:hasTypedValue edo:floatValue ;
+                                   edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#StopperCollar
-:StopperCollar rdf:type owl:Class ;
-               rdfs:subClassOf :SplitCollar ;
+edo:StopperCollar rdf:type owl:Class ;
+               rdfs:subClassOf edo:SplitCollar ;
                dcterms:identifier "StopperCollar" ;
                skos:altLabel "Locking Collar"@en ,
                              "Positioning Collar"@en ,
@@ -5847,265 +5846,265 @@ rdf:value rdf:type owl:DatatypeProperty .
                skos:definition "A component used to prevent the movement or displacement of other parts in subsea systems. The Stopper Collar is installed around the pipe or component and acts as a physical barrier to stop or limit movement, ensuring components stay in their intended positions. It is crucial for maintaining alignment and stability during installation, operation, or maintenance, providing secure positioning and preventing unwanted shifts or displacements."@en ;
                skos:prefLabel "Colar Batente"@pt-br ,
                               "Stopper Collar"@en ;
-               :ifc_equivalentClass "IfcPipeFitting" ;
-               :ifc_objectType "StopperCollar" ;
-               :ifc_predefinedType "USERDEFINED" .
+               edo:ifc_equivalentClass "IfcPipeFitting" ;
+               edo:ifc_objectType "StopperCollar" ;
+               edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#StorageAccessory
-:StorageAccessory rdf:type owl:Class ;
-                  rdfs:subClassOf :Accessory ;
+edo:StorageAccessory rdf:type owl:Class ;
+                  rdfs:subClassOf edo:Accessory ;
                   dcterms:identifier "StorageAccessory" .
 
 
 ###  https://w3id.org/energy-domain/edo#StorageBox
-:StorageBox rdf:type owl:Class ;
-            rdfs:subClassOf :StorageAccessory ;
+edo:StorageBox rdf:type owl:Class ;
+            rdfs:subClassOf edo:StorageAccessory ;
             dcterms:identifier "StorageBox" .
 
 
 ###  https://w3id.org/energy-domain/edo#StorageSkid
-:StorageSkid rdf:type owl:Class ;
-             rdfs:subClassOf :StorageAccessory ;
+edo:StorageSkid rdf:type owl:Class ;
+             rdfs:subClassOf edo:StorageAccessory ;
              dcterms:identifier "StorageSkid" .
 
 
 ###  https://w3id.org/energy-domain/edo#StorageSpool
-:StorageSpool rdf:type owl:Class ;
-              rdfs:subClassOf :StorageAccessory ;
+edo:StorageSpool rdf:type owl:Class ;
+              rdfs:subClassOf edo:StorageAccessory ;
               dcterms:identifier "StorageSpool" .
 
 
 ###  https://w3id.org/energy-domain/edo#StrIntOffPLevMaxPress
-:StrIntOffPLevMaxPress rdf:type owl:Class ;
-                       rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:StrIntOffPLevMaxPress rdf:type owl:Class ;
+                       rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
                        dcterms:accessRights "PUBLIC" ;
                        dcterms:identifier "StrIntOffPLevMaxPress" ;
                        skos:definition "Condições de teste dos tramos para Pressão - Máxima - Teste de integridade estrutural hidrostática (off-shore, no nível da plataforma)"@pt-br ,
                                        "The maximum pressure applied during the Structural Integrity Test (offshore, at platform level), ensuring structural integrity under extreme conditions."@en ;
                        skos:prefLabel "Integridade Estrutural Offshore com Pressão Máxima no Nível da Plataforma"@pt-br ,
                                       "Structural Integrity Offshore Leak Test At Platform Level Maximum Pressure"@en ;
-                       :hasAttributeScope :InstanceLevelAttribute ;
-                       :hasTypedValue :floatValue ;
-                       :hasValueCardinality :singleValue .
+                       edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                       edo:hasTypedValue edo:floatValue ;
+                       edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#StrIntOffPLevMaxPressValRef
-:StrIntOffPLevMaxPressValRef rdf:type owl:Class ;
-                             rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:StrIntOffPLevMaxPressValRef rdf:type owl:Class ;
+                             rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
                              dcterms:accessRights "PUBLIC" ;
                              dcterms:identifier "StrIntOffPLevMaxPressValRef" ;
                              skos:definition "Comentários Condições de teste dos tramos para - Máximo - Teste de integridade estrutural hidrostática (off-shore, no nível da plataforma)"@pt-br ,
                                              "Specifies the reference pressure used to determine the Structural Offshore Maximum Pressure value."@en ;
                              skos:prefLabel "Referência de Valor de Pressão Máxima para Teste de Integridade Estrutural Offshore e de Vazamento no Nível da Plataforma"@pt-br ,
                                             "Structural Integrity Offshore Leak Test At Platform Level Maximum Pressure Value Reference"@en ;
-                             :hasAttributeScope :InstanceLevelAttribute ;
-                             :hasTypedValue :stringValue ;
-                             :hasValueCardinality :singleValue .
+                             edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                             edo:hasTypedValue edo:stringValue ;
+                             edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#StrIntOffPLevMaxPressValRefMult
-:StrIntOffPLevMaxPressValRefMult rdf:type owl:Class ;
-                                 rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:StrIntOffPLevMaxPressValRefMult rdf:type owl:Class ;
+                                 rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
                                  dcterms:accessRights "PUBLIC" ;
                                  dcterms:identifier "StrIntOffPLevMaxPressValRefMult" ;
                                  skos:definition "The multiplier applied to the reference pressure to determine the Structural Offshore Maximum Pressure value."@en ;
                                  skos:prefLabel "Multiplicador de Referência de Valor de Pressão Máxima para Teste de Integridade Estrutural Offshore no Nível da Plataforma"@pt-br ,
                                                 "Structural Integrity Offshore Leak Test At Platform Level Maximum Pressure Value Reference Multiplier"@en ;
-                                 :hasAttributeScope :InstanceLevelAttribute ;
-                                 :hasTypedValue :floatValue ;
-                                 :hasValueCardinality :singleValue .
+                                 edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                 edo:hasTypedValue edo:floatValue ;
+                                 edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#StrIntOffPLevNomPress
-:StrIntOffPLevNomPress rdf:type owl:Class ;
-                       rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:StrIntOffPLevNomPress rdf:type owl:Class ;
+                       rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
                        dcterms:accessRights "PUBLIC" ;
                        dcterms:identifier "StrIntOffPLevNomPress" ;
                        skos:definition "Condições de teste dos tramos para Pressão - Nominal - Teste de integridade estrutural hidrostática (off-shore, no nível da plataforma)"@pt-br ,
                                        "The nominal pressure applied during the Structural Integrity Test (offshore, at platform level), simulating typical conditions to verify structural integrity."@en ;
                        skos:prefLabel "Integridade Estrutural Offshore com Pressão Nominal no Nível da Plataforma"@pt-br ,
                                       "Structural Integrity Offshore Leak Test At Platform Level Nominal Pressure"@en ;
-                       :hasAttributeScope :InstanceLevelAttribute ;
-                       :hasTypedValue :floatValue ;
-                       :hasValueCardinality :singleValue .
+                       edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                       edo:hasTypedValue edo:floatValue ;
+                       edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#StrIntOffPLevNomPressValRef
-:StrIntOffPLevNomPressValRef rdf:type owl:Class ;
-                             rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:StrIntOffPLevNomPressValRef rdf:type owl:Class ;
+                             rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
                              dcterms:accessRights "PUBLIC" ;
                              dcterms:identifier "StrIntOffPLevNomPressValRef" ;
                              skos:definition "Comentários Condições de teste dos tramos para - Nominal - Teste de integridade estrutural hidrostática (off-shore, no nível da plataforma)"@pt-br ,
                                              "Specifies the reference pressure used to determine the Structural Offshore Leak Test Nominal Pressure value."@en ;
                              skos:prefLabel "Referência de Valor de Pressão Nominal para Teste de Integridade Estrutural Offshore no Nível da Plataforma"@pt-br ,
                                             "Structural Integrity Offshore Leak Test At Platform Level Nominal Pressure Value Reference"@en ;
-                             :hasAttributeScope :InstanceLevelAttribute ;
-                             :hasTypedValue :stringValue ;
-                             :hasValueCardinality :singleValue .
+                             edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                             edo:hasTypedValue edo:stringValue ;
+                             edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#StrIntOffPLevNomPressValRefMult
-:StrIntOffPLevNomPressValRefMult rdf:type owl:Class ;
-                                 rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:StrIntOffPLevNomPressValRefMult rdf:type owl:Class ;
+                                 rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
                                  dcterms:accessRights "PUBLIC" ;
                                  dcterms:identifier "StrIntOffPLevNomPressValRefMult" ;
                                  skos:definition "The multiplier applied to the reference pressure to determine the Structural Offshore Nominal Pressure value."@en ;
                                  skos:prefLabel "Multiplicador de Referência de Valor de Pressão Nominal para Teste de Integridade Estrutural Offshore no Nível da Plataforma"@pt-br ,
                                                 "Structural Integrity Offshore Leak Test At Platform Level Nominal Pressure Value Reference Multiplier"@en ;
-                                 :hasAttributeScope :InstanceLevelAttribute ;
-                                 :hasTypedValue :floatValue ;
-                                 :hasValueCardinality :singleValue .
+                                 edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                 edo:hasTypedValue edo:floatValue ;
+                                 edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#StrIntOnNoTensMaxPress
-:StrIntOnNoTensMaxPress rdf:type owl:Class ;
-                        rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:StrIntOnNoTensMaxPress rdf:type owl:Class ;
+                        rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
                         dcterms:accessRights "PUBLIC" ;
                         dcterms:identifier "StrIntOnNoTensMaxPress" ;
                         skos:definition "Condições de teste dos tramos para Pressão - Máxima - Teste de integridade estrutural hidrostática (a bordo, sem tensão)"@pt-br ,
                                         "The maximum pressure applied during the Structural Integrity Test (onboard, without tension), verifying performance under extreme conditions."@en ;
                         skos:prefLabel "Integridade Estrutural a Bordo sem Pressão Máxima de Tensão"@pt-br ,
                                        "Structural Integrity Onboard With No Tension Maximum Pressure"@en ;
-                        :hasAttributeScope :InstanceLevelAttribute ;
-                        :hasTypedValue :floatValue ;
-                        :hasValueCardinality :singleValue .
+                        edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                        edo:hasTypedValue edo:floatValue ;
+                        edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#StrIntOnNoTensMaxPressValRef
-:StrIntOnNoTensMaxPressValRef rdf:type owl:Class ;
-                              rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:StrIntOnNoTensMaxPressValRef rdf:type owl:Class ;
+                              rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
                               dcterms:accessRights "PUBLIC" ;
                               dcterms:identifier "StrIntOnNoTensMaxPressValRef" ;
                               skos:definition "Comentários Condições de teste dos tramos para - Máximo - Teste de integridade estrutural hidrostática (a bordo, sem tensão)"@pt-br ,
                                               "Specifies the reference pressure used to determine the Structural Onboard Maximum Pressure value."@en ;
                               skos:prefLabel "Referência de Valor de Pressão Máxima para Integridade Estrutural a Bordo sem Tensão"@pt-br ,
                                              "Structural Integrity Onboard With No Tension Maximum Pressure Value Reference"@en ;
-                              :hasAttributeScope :InstanceLevelAttribute ;
-                              :hasTypedValue :stringValue ;
-                              :hasValueCardinality :singleValue .
+                              edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                              edo:hasTypedValue edo:stringValue ;
+                              edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#StrIntOnNoTensMaxPressValRefMult
-:StrIntOnNoTensMaxPressValRefMult rdf:type owl:Class ;
-                                  rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:StrIntOnNoTensMaxPressValRefMult rdf:type owl:Class ;
+                                  rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
                                   dcterms:accessRights "PUBLIC" ;
                                   dcterms:identifier "StrIntOnNoTensMaxPressValRefMult" ;
                                   skos:definition "The multiplier applied to the reference pressure to determine the Structural Onboard Maximum Pressure value."@en ;
                                   skos:prefLabel "Multiplicador de Referência de Valor de Pressão Máxima para Integridade Estrutural a Bordo sem Tensão"@pt-br ,
                                                  "Structural Integrity Onboard With No Tension Maximum Pressure Value Reference Multiplier"@en ;
-                                  :hasAttributeScope :InstanceLevelAttribute ;
-                                  :hasTypedValue :floatValue ;
-                                  :hasValueCardinality :singleValue .
+                                  edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                  edo:hasTypedValue edo:floatValue ;
+                                  edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#StrIntOnNoTensNomPress
-:StrIntOnNoTensNomPress rdf:type owl:Class ;
-                        rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:StrIntOnNoTensNomPress rdf:type owl:Class ;
+                        rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
                         dcterms:accessRights "PUBLIC" ;
                         dcterms:identifier "StrIntOnNoTensNomPress" ;
                         skos:definition "Condições de teste dos tramos para Pressão - Nominal - Teste de integridade estrutural hidrostática (on-board, sem tensão)"@pt-br ,
                                         "The nominal pressure applied during the Structural Integrity Test (onboard, without tension), simulating typical conditions to verify structural integrity."@en ;
                         skos:prefLabel "Integridade Estrutural a Bordo sem Pressão Nominal de Tensão"@pt-br ,
                                        "Structural Integrity Onboard With No Tension Nominal Pressure"@en ;
-                        :hasAttributeScope :InstanceLevelAttribute ;
-                        :hasTypedValue :floatValue ;
-                        :hasValueCardinality :singleValue .
+                        edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                        edo:hasTypedValue edo:floatValue ;
+                        edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#StrIntOnNoTensNomPressValRef
-:StrIntOnNoTensNomPressValRef rdf:type owl:Class ;
-                              rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:StrIntOnNoTensNomPressValRef rdf:type owl:Class ;
+                              rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
                               dcterms:accessRights "PUBLIC" ;
                               dcterms:identifier "StrIntOnNoTensNomPressValRef" ;
                               skos:definition "Comentários Condições de teste dos tramos para - Nominal - Teste de integridade estrutural hidrostática (on-board, sem tensão)"@pt-br ,
                                               "Specifies the reference pressure used to determine the Structural Onboard Nominal Pressure value."@en ;
                               skos:prefLabel "Integridade Estrutural a Bordo sem Referência de Valor de Pressão Nominal de Tensão"@pt-br ,
                                              "Structural Integrity Onboard With No Tension Nominal Pressure Value Reference"@en ;
-                              :hasAttributeScope :InstanceLevelAttribute ;
-                              :hasTypedValue :stringValue ;
-                              :hasValueCardinality :singleValue .
+                              edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                              edo:hasTypedValue edo:stringValue ;
+                              edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#StrIntOnNoTensNomPressValRefMult
-:StrIntOnNoTensNomPressValRefMult rdf:type owl:Class ;
-                                  rdfs:subClassOf :HydrostaticPressureTestsAttribute ;
+edo:StrIntOnNoTensNomPressValRefMult rdf:type owl:Class ;
+                                  rdfs:subClassOf edo:HydrostaticPressureTestsAttribute ;
                                   dcterms:accessRights "PUBLIC" ;
                                   dcterms:identifier "StrIntOnNoTensNomPressValRefMult" ;
                                   skos:definition "The multiplier applied to the reference pressure to determine the Structural Onboard Nominal Pressure value."@en ;
                                   skos:prefLabel "Multiplicador de Referência de Valor de Pressão Nominal para Integridade Estrutural a Bordo sem Tensão"@pt-br ,
                                                  "Structural Integrity Onboard With No Tension Nominal Pressure Value Reference Multiplier"@en ;
-                                  :hasAttributeScope :InstanceLevelAttribute ;
-                                  :hasTypedValue :floatValue ;
-                                  :hasValueCardinality :singleValue .
+                                  edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                                  edo:hasTypedValue edo:floatValue ;
+                                  edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#StrandsTableAttribute
-:StrandsTableAttribute rdf:type owl:Class ;
-                       rdfs:subClassOf :DomainAttribute ;
+edo:StrandsTableAttribute rdf:type owl:Class ;
+                       rdfs:subClassOf edo:DomainAttribute ;
                        dcterms:accessRights "PUBLIC" ;
                        dcterms:identifier "StrandsTableAttribute" ;
                        skos:definition "Provides detailed information about the mechanical and geometrical properties, including dimensions and material characteristics, necessary for understanding and evaluating the component's performance and suitability for its intended application."@en ;
                        skos:prefLabel "Strands Table"@en ,
                                       "Tabela de Propriedades das Cordoalhas"@pt-br ;
-                       :hasAttributeScope :InstanceLevelAttribute .
+                       edo:hasAttributeScope edo:InstanceLevelAttribute .
 
 
 ###  https://w3id.org/energy-domain/edo#StrandsTable_SpareQuantity
-:StrandsTable_SpareQuantity rdf:type owl:Class ;
-                            rdfs:subClassOf :StrandsTableAttribute ;
+edo:StrandsTable_SpareQuantity rdf:type owl:Class ;
+                            rdfs:subClassOf edo:StrandsTableAttribute ;
                             dcterms:accessRights "PUBLIC" ;
                             dcterms:identifier "StrandsTable_SpareQuantity" ;
                             skos:definition "Specifies the number of spare units available, ensuring adequate backup components are on hand for maintenance or replacement. This quantity helps in planning and minimizing downtime during operations in subsea environments."@en ;
                             skos:prefLabel "Quantidade de Sobressalentes"@pt-br ,
                                            "Spare Quantity"@en ;
-                            :hasAttributeScope :InstanceLevelAttribute ;
-                            :hasTypedValue :intValue ;
-                            :hasValueCardinality :multiValue .
+                            edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                            edo:hasTypedValue edo:intValue ;
+                            edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#StrandsTable_StrandsLength
-:StrandsTable_StrandsLength rdf:type owl:Class ;
-                            rdfs:subClassOf :StrandsTableAttribute ;
+edo:StrandsTable_StrandsLength rdf:type owl:Class ;
+                            rdfs:subClassOf edo:StrandsTableAttribute ;
                             dcterms:accessRights "PUBLIC" ;
                             dcterms:identifier "StrandsTable_StrandsLength" ;
                             skos:definition "Length of the individual strands."@en ;
                             skos:prefLabel "Comprimento das Cordoalhas"@pt-br ,
                                            "Strands Length"@en ;
-                            :hasAttributeScope :InstanceLevelAttribute ;
-                            :hasTypedValue :floatValue ;
-                            :hasValueCardinality :multiValue .
+                            edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                            edo:hasTypedValue edo:floatValue ;
+                            edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#StrandsTable_StrandsQuantity
-:StrandsTable_StrandsQuantity rdf:type owl:Class ;
-                              rdfs:subClassOf :StrandsTableAttribute ;
+edo:StrandsTable_StrandsQuantity rdf:type owl:Class ;
+                              rdfs:subClassOf edo:StrandsTableAttribute ;
                               dcterms:accessRights "PUBLIC" ;
                               dcterms:identifier "StrandsTable_StrandsQuantity" ;
                               skos:definition "Number of individual strands used, determining the overall reinforcement and strength of the component."@en ;
                               skos:prefLabel "Quantidade de Cordoalhas"@pt-br ,
                                              "Strands Quantity"@en ;
-                              :hasAttributeScope :InstanceLevelAttribute ;
-                              :hasTypedValue :intValue ;
-                              :hasValueCardinality :multiValue .
+                              edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                              edo:hasTypedValue edo:intValue ;
+                              edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#StressAtDesignPressure
-:StressAtDesignPressure rdf:type owl:Class ;
-                        rdfs:subClassOf :DomainAttribute ;
+edo:StressAtDesignPressure rdf:type owl:Class ;
+                        rdfs:subClassOf edo:DomainAttribute ;
                         dcterms:accessRights "PUBLIC" ;
                         dcterms:identifier "StressAtDesignPressure" ;
                         skos:definition "Maximum stress that the material can withstand when subjected to design pressure is specified. This parameter is critical for ensuring that the material maintains its structural integrity and performs reliably under the operational pressure conditions specified in the design."@en ;
                         skos:prefLabel "Stress At Design Pressure"@en ,
                                        "Tensão na pressão de projeto"@pt-br ;
-                        :hasAttributeScope :InstanceLevelAttribute ;
-                        :hasTypedValue :floatValue ;
-                        :hasValueCardinality :singleValue .
+                        edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                        edo:hasTypedValue edo:floatValue ;
+                        edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#StructuralEngineering
-:StructuralEngineering rdf:type owl:Class ;
-                       rdfs:subClassOf :CivilEngineering ;
+edo:StructuralEngineering rdf:type owl:Class ;
+                       rdfs:subClassOf edo:CivilEngineering ;
                        rdfs:label "Engenharia Estrutural"@pt-br ,
                                   "Structural Engineering"@en ;
                        skos:definition "Disciplina de engenharia focada na integridade estrutural e projeto de edifícios e infraestrutura."@pt-br ,
@@ -6113,84 +6112,84 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#Structure
-:Structure rdf:type owl:Class ;
-           rdfs:subClassOf :CompactObject ;
+edo:Structure rdf:type owl:Class ;
+           rdfs:subClassOf edo:CompactObject ;
            dcterms:identifier "Structure" .
 
 
 ###  https://w3id.org/energy-domain/edo#StructureApplicationsList
-:StructureApplicationsList rdf:type owl:Class ;
-                           rdfs:subClassOf :DomainAttribute ;
+edo:StructureApplicationsList rdf:type owl:Class ;
+                           rdfs:subClassOf edo:DomainAttribute ;
                            dcterms:accessRights "PUBLIC" ;
                            dcterms:identifier "StructureApplicationsList" ;
                            skos:definition "Indicates the possible positions where the structure can be applied along the pipeline system. Multiple values can be selected to show in which sections, such as different parts of a riser or flowline, the structure is suitable for use."@en ,
                                            "Lista de todas as possíveis aplicações para a estrutura Valores aplicáveis (Mais de um valor pode ser escolhido): R (Riser) RT (Para seção de topo do riser) RI (Para seção intermediaria do riser) RF (Para seção de fundo do riser) F (Para Flowline)"@pt-br ;
                            skos:prefLabel "Lista de Aplicações da Estrutura"@pt-br ,
                                           "Structure Applications List"@en ;
-                           :hasAttributeScope :TypeLevelAttribute ;
-                           :hasTypedValue :stringValue ;
-                           :hasValueCardinality :multiValue .
+                           edo:hasAttributeScope edo:TypeLevelAttribute ;
+                           edo:hasTypedValue edo:stringValue ;
+                           edo:hasValueCardinality edo:multiValue .
 
 
 ###  https://w3id.org/energy-domain/edo#StructureCode
-:StructureCode rdf:type owl:Class ;
-               rdfs:subClassOf :DomainAttribute ;
+edo:StructureCode rdf:type owl:Class ;
+               rdfs:subClassOf edo:DomainAttribute ;
                dcterms:accessRights "PUBLIC" ;
                dcterms:identifier "StructureCode" ;
                skos:definition "Indicates the code or identifier assigned to the structure. This property is used to uniquely identify and reference the structure within a system, ensuring proper tracking, documentation, and management."@en ;
                skos:prefLabel "Código da estrutura"@pt-br ,
                               "Structure Code"@en ;
-               :hasAttributeScope :TypeLevelAttribute ;
-               :hasTypedValue :stringValue ;
-               :hasValueCardinality :singleValue .
+               edo:hasAttributeScope edo:TypeLevelAttribute ;
+               edo:hasTypedValue edo:stringValue ;
+               edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#StudSet
-:StudSet rdf:type owl:Class ;
-         rdfs:subClassOf :PhysicalConnection ;
+edo:StudSet rdf:type owl:Class ;
+         rdfs:subClassOf edo:PhysicalConnection ;
          dcterms:identifier "StudSet" ;
          skos:altLabel "Stud"@en ,
                        "Threaded Rod"@en ;
          skos:definition "Stud sets are essential fastening components used in subsea oil and gas interconnection end fittings to securely assemble and connect various parts of the equipment. Each set typically includes bolts, nuts, and washers, all made from high-strength, corrosion-resistant materials to endure the harsh subsea environment. These components are designed to provide reliable mechanical fastening, ensuring the structural integrity and leak-proof performance of the end fittings. The stud sets are carefully engineered to withstand high pressure and extreme temperatures, making them critical for maintaining the operational safety and longevity of subsea interconnections."@en ;
          skos:prefLabel "Estojos"@pt-br ,
                         "Stud Set"@en ;
-         :hasAttribute :AssemblyTorque ,
-                       :FullyThreaded ,
-                       :Lubricant ,
-                       :LubricantFrictionFactor ,
-                       :NominalDiameter ,
-                       :Quantity ,
-                       :SpareQuantity .
+         edo:hasAttribute edo:AssemblyTorque ,
+                       edo:FullyThreaded ,
+                       edo:Lubricant ,
+                       edo:LubricantFrictionFactor ,
+                       edo:NominalDiameter ,
+                       edo:Quantity ,
+                       edo:SpareQuantity .
 
 
 ###  https://w3id.org/energy-domain/edo#SubProjectId
-:SubProjectId rdf:type owl:Class ;
-              rdfs:subClassOf :DomainAttribute ;
+edo:SubProjectId rdf:type owl:Class ;
+              rdfs:subClassOf edo:DomainAttribute ;
               dcterms:accessRights "PUBLIC" ;
               dcterms:identifier "SubProjectId" ;
               skos:definition "Refers to the identification code assigned to the well or piece of equipment for which the interconnection is being designed. This code is often provisional, used during the initial stages of development, such as during the fabrication or installation of flexible pipelines, before a final approval or designation is granted. It serves as a reference point for all equipment and documentation until the well or equipment receives its definitive identification from the relevant regulatory authority. Examples include codes like LL-S.P6, LL-S.MSIAG1, or simpler identifiers such as P6 or MSIAG1."@en ;
               skos:prefLabel "Id do Subprojeto"@pt-br ,
                              "Sub Project Id"@en ;
-              :hasAttributeScope :InstanceLevelAttribute ;
-              :hasTypedValue :stringValue ;
-              :hasValueCardinality :singleValue .
+              edo:hasAttributeScope edo:InstanceLevelAttribute ;
+              edo:hasTypedValue edo:stringValue ;
+              edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#SubseaConnectionPoint
-:SubseaConnectionPoint rdf:type owl:Class ;
-                       rdfs:subClassOf :LogicalConnection ;
+edo:SubseaConnectionPoint rdf:type owl:Class ;
+                       rdfs:subClassOf edo:LogicalConnection ;
                        dcterms:identifier "SubseaConnectionPoint" ;
                        skos:definition "The Subsea Connection Point is the interface on subsea equipment where a flexible pipe connects. It serves as the critical link between the flexible pipe and subsea systems, enabling the transfer of fluids or gases. Designed to withstand high pressures and harsh underwater conditions, the Subsea External Point ensures a secure and reliable connection, facilitating efficient operation of various subsea systems."@en ;
                        skos:prefLabel "Ponto de Conexão Submarino"@pt-br ,
                                       "Subsea Connection Point"@en ;
-                       :ifc_equivalentClass "IfcPipeFitting" ;
-                       :ifc_objectType "SubseaConnectionPoint" ;
-                       :ifc_predefinedType "USERDEFINED" .
+                       edo:ifc_equivalentClass "IfcPipeFitting" ;
+                       edo:ifc_objectType "SubseaConnectionPoint" ;
+                       edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#SubseaEngineering
-:SubseaEngineering rdf:type owl:Class ;
-                   rdfs:subClassOf :TechnicalDiscipline ;
+edo:SubseaEngineering rdf:type owl:Class ;
+                   rdfs:subClassOf edo:TechnicalDiscipline ;
                    rdfs:label "Engenharia Submarina"@pt-br ,
                               "Subsea Engineering"@en ;
                    skos:definition "Disciplina de engenharia focada em sistemas e equipamentos subaquáticos para operações offshore."@pt-br ,
@@ -6198,26 +6197,26 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#SubseaEquipment
-:SubseaEquipment rdf:type owl:Class ;
-                 rdfs:subClassOf :Equipment ;
+edo:SubseaEquipment rdf:type owl:Class ;
+                 rdfs:subClassOf edo:Equipment ;
                  dcterms:identifier "SubseaEquipment" .
 
 
 ###  https://w3id.org/energy-domain/edo#SubseaFlexiblePipesBsddDictionary
-:SubseaFlexiblePipesBsddDictionary rdf:type owl:Class ;
-                                   rdfs:subClassOf :DomainElement ;
+edo:SubseaFlexiblePipesBsddDictionary rdf:type owl:Class ;
+                                   rdfs:subClassOf edo:DomainElement ;
                                    dcterms:identifier "SubseaFlexiblePipesBsddDictionary" ;
                                    skos:definition "Bsdd Dictionary of Subsea Flexible Pipelines."@en ;
                                    skos:prefLabel "Dicionário Bsdd de Dutos Flexíveis Submarinos"@pt-br ,
                                                   "Subsea Flexible Pipes Bsdd Dictionary"@en ;
-                                   :ifc_equivalentClass "IfcClassification" ;
-                                   :ifc_objectType "SubseaFlexiblePipesBsddDictionary" ;
-                                   :ifc_predefinedType "USERDEFINED" .
+                                   edo:ifc_equivalentClass "IfcClassification" ;
+                                   edo:ifc_objectType "SubseaFlexiblePipesBsddDictionary" ;
+                                   edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#SubseaFlexiblePipesEngineering
-:SubseaFlexiblePipesEngineering rdf:type owl:Class ;
-                                rdfs:subClassOf :SubseaEngineering ;
+edo:SubseaFlexiblePipesEngineering rdf:type owl:Class ;
+                                rdfs:subClassOf edo:SubseaEngineering ;
                                 rdfs:label "Engenharia de Tubos Flexíveis Submarinos"@pt-br ,
                                            "Subsea Flexible Pipes Engineering"@en ;
                                 skos:definition "Engenharia de sistemas de tubos flexíveis utilizados em aplicações submarinas."@pt-br ,
@@ -6225,8 +6224,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#SubseaLayout
-:SubseaLayout rdf:type owl:Class ;
-              rdfs:subClassOf :Location ;
+edo:SubseaLayout rdf:type owl:Class ;
+              rdfs:subClassOf edo:Location ;
               dcterms:identifier "SubseaLayout" ;
               skos:definition "The arrangement or map of components and systems within a subsea environment, including pipelines, risers, manifolds, and other infrastructure."@en ;
               skos:prefLabel "Arranjo Submarino"@pt-br ,
@@ -6234,8 +6233,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#SubseaOilField
-:SubseaOilField rdf:type owl:Class ;
-                rdfs:subClassOf :SubseaLayout ;
+edo:SubseaOilField rdf:type owl:Class ;
+                rdfs:subClassOf edo:SubseaLayout ;
                 dcterms:identifier "SubseaOilField" ;
                 skos:altLabel "Subsea Hydrocarbon Field"@en ,
                               "Subsea Oil Reservoir"@en ,
@@ -6244,51 +6243,51 @@ rdf:value rdf:type owl:DatatypeProperty .
                 skos:definition "A subsea oil field refers to an underwater reservoir of hydrocarbons located beneath the seabed. It involves the extraction of oil and gas from deposits situated in deepwater or shallow marine environments. The subsea oil field includes a range of equipment and infrastructure, such as subsea wells, pipelines, and production systems, all designed to safely and efficiently extract and transport hydrocarbons to processing facilities on the surface or shore. The development and operation of subsea oil fields require specialized technology and expertise to manage the challenges of deepwater environments and ensure the successful production and handling of resources."@en ;
                 skos:prefLabel "Campo de Petróleo Submarino"@pt-br ,
                                "Subsea Oil Field"@en ;
-                :ifc_equivalentClass "IfcSite" ;
-                :ifc_objectType "SubseaOilField" .
+                edo:ifc_equivalentClass "IfcSite" ;
+                edo:ifc_objectType "SubseaOilField" .
 
 
 ###  https://w3id.org/energy-domain/edo#SubseaPipeline
-:SubseaPipeline rdf:type owl:Class ;
-                rdfs:subClassOf :Interconnection ;
+edo:SubseaPipeline rdf:type owl:Class ;
+                rdfs:subClassOf edo:Interconnection ;
                 dcterms:identifier "SubseaPipeline" ;
                 skos:definition "A Subsea Pipeline is a conduit installed on the seafloor designed to transport oil, gas, or other fluids from underwater production facilities to processing or storage locations on the surface or shore. Engineered to withstand harsh underwater conditions, including high pressures, corrosive environments, and dynamic movements, the Subsea Pipeline is constructed with durable materials and advanced technologies to ensure reliable and efficient fluid transfer."@en ;
                 skos:prefLabel "Linha Submarina"@pt-br ,
                                "Subsea Pipeline"@en ;
-                :hasAttribute :BasicProjectRevision ,
-                              :CO2VolumePercentage ,
-                              :ExecutiveProjectRevision ,
-                              :H2SVolumeConcentration ,
-                              :InternalDiameter ,
-                              :InternalIncidentalPressureTable ,
-                              :InternalIncidentalPressureTable_PositionReference ,
-                              :InternalIncidentalPressureTable_Pressure ,
-                              :InternalIncidentalPressureTable_VPosWRTWaterline ,
-                              :MaterialRequest ,
-                              :MaterialRequestRev ,
-                              :MaxDesignAbsIntPresTable ,
-                              :MaxDesignAbsIntPresTable_PositionReference ,
-                              :MaxDesignAbsIntPresTable_Pressure ,
-                              :MaxDesignAbsIntPresTable_VPosWRTWaterline ,
-                              :MaximumTemperature ,
-                              :MaximumThermalExchangeCoefficient ,
-                              :MinimumThermalExchangeCoefficient ,
-                              :NominalLength ,
-                              :ProjectAcronym ,
-                              :ProjectCode ,
-                              :RiserConfiguration ,
-                              :Service ,
-                              :SubProjectId ,
-                              :UnifilarDiagram ,
-                              :UnifilarDiagramRev ;
-                :ifc_equivalentClass "IfcBuilding" ;
-                :ifc_objectType "SubseaPipeline" ;
-                :ifc_predefinedType "USERDEFINED" .
+                edo:hasAttribute edo:BasicProjectRevision ,
+                              edo:CO2VolumePercentage ,
+                              edo:ExecutiveProjectRevision ,
+                              edo:H2SVolumeConcentration ,
+                              edo:InternalDiameter ,
+                              edo:InternalIncidentalPressureTable ,
+                              edo:InternalIncidentalPressureTable_PositionReference ,
+                              edo:InternalIncidentalPressureTable_Pressure ,
+                              edo:InternalIncidentalPressureTable_VPosWRTWaterline ,
+                              edo:MaterialRequest ,
+                              edo:MaterialRequestRev ,
+                              edo:MaxDesignAbsIntPresTable ,
+                              edo:MaxDesignAbsIntPresTable_PositionReference ,
+                              edo:MaxDesignAbsIntPresTable_Pressure ,
+                              edo:MaxDesignAbsIntPresTable_VPosWRTWaterline ,
+                              edo:MaximumTemperature ,
+                              edo:MaximumThermalExchangeCoefficient ,
+                              edo:MinimumThermalExchangeCoefficient ,
+                              edo:NominalLength ,
+                              edo:ProjectAcronym ,
+                              edo:ProjectCode ,
+                              edo:RiserConfiguration ,
+                              edo:Service ,
+                              edo:SubProjectId ,
+                              edo:UnifilarDiagram ,
+                              edo:UnifilarDiagramRev ;
+                edo:ifc_equivalentClass "IfcBuilding" ;
+                edo:ifc_objectType "SubseaPipeline" ;
+                edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#SubseaRigidPipesEngineering
-:SubseaRigidPipesEngineering rdf:type owl:Class ;
-                             rdfs:subClassOf :SubseaEngineering ;
+edo:SubseaRigidPipesEngineering rdf:type owl:Class ;
+                             rdfs:subClassOf edo:SubseaEngineering ;
                              rdfs:label "Engenharia de Tubos Rígidos Submarinos"@pt-br ,
                                         "Subsea Rigid Pipes Engineering"@en ;
                              skos:definition "Engenharia de sistemas de tubulações rígidas utilizadas em aplicações submarinas."@pt-br ,
@@ -6296,8 +6295,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#SubseaStructuresEngineering
-:SubseaStructuresEngineering rdf:type owl:Class ;
-                             rdfs:subClassOf :SubseaEngineering ;
+edo:SubseaStructuresEngineering rdf:type owl:Class ;
+                             rdfs:subClassOf edo:SubseaEngineering ;
                              rdfs:label "Engenharia de Estruturas Submarinas"@pt-br ,
                                         "Subsea Structures Engineering"@en ;
                              skos:definition "Engenharia de manifolds submarinos, árvores de natal e outros componentes estruturais."@pt-br ,
@@ -6305,8 +6304,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#SubseaUmbilicalsEngineering
-:SubseaUmbilicalsEngineering rdf:type owl:Class ;
-                             rdfs:subClassOf :SubseaEngineering ;
+edo:SubseaUmbilicalsEngineering rdf:type owl:Class ;
+                             rdfs:subClassOf edo:SubseaEngineering ;
                              rdfs:label "Engenharia de Umbilicais Submarinos"@pt-br ,
                                         "Subsea Umbilicals Engineering"@en ;
                              skos:definition "Engenharia de sistemas de umbilicais submarinos fornecendo controle, energia e injeção química."@pt-br ,
@@ -6314,58 +6313,58 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#SubseaWell
-:SubseaWell rdf:type owl:Class ;
-            rdfs:subClassOf :EquipmentLocation ;
+edo:SubseaWell rdf:type owl:Class ;
+            rdfs:subClassOf edo:EquipmentLocation ;
             dcterms:identifier "SubseaWell" ;
             skos:definition "A Subsea Well is a well located on the seafloor from which hydrocarbons such as oil and gas are extracted. Positioned underwater, it typically involves a wellhead assembly that includes valves, controls, and monitoring equipment to manage the extraction process. The Subsea Well is connected to surface facilities via pipelines and umbilicals, which facilitate the transport of extracted resources and the provision of necessary services like power and communication. Designed to operate under high pressure and harsh marine conditions, the subsea well is a critical component of offshore oil and gas production systems."@en ;
             skos:prefLabel "Poço"@pt-br ,
                            "Subsea Well"@en ;
-            :ifc_equivalentClass "IfcBuilding" ;
-            :ifc_objectType "SubseaWell" ;
-            :ifc_predefinedType "USERDEFINED" .
+            edo:ifc_equivalentClass "IfcBuilding" ;
+            edo:ifc_objectType "SubseaWell" ;
+            edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#SuctionPile
-:SuctionPile rdf:type owl:Class ;
-             rdfs:subClassOf :Pile ;
+edo:SuctionPile rdf:type owl:Class ;
+             rdfs:subClassOf edo:Pile ;
              dcterms:identifier "SuctionPile" .
 
 
 ###  https://w3id.org/energy-domain/edo#SupplierProvidedMaterialName
-:SupplierProvidedMaterialName rdf:type owl:Class ;
-                              rdfs:subClassOf :MaterialManufacturerAttribute ;
+edo:SupplierProvidedMaterialName rdf:type owl:Class ;
+                              rdfs:subClassOf edo:MaterialManufacturerAttribute ;
                               dcterms:accessRights "PUBLIC" ;
                               dcterms:identifier "SupplierProvidedMaterialName" ;
                               skos:definition "Name of the material as specified by the original supplier. This property identifies the exact material provided, ensuring it aligns with the required specifications for the accessory."@en ;
                               skos:prefLabel "Nome do material conforme designado pelo fornecedor original do material"@pt-br ,
                                              "Supplier Provided Material Name"@en ;
-                              :hasAttributeScope :TypeLevelAttribute ;
-                              :hasTypedValue :stringValue ;
-                              :hasValueCardinality :singleValue .
+                              edo:hasAttributeScope edo:TypeLevelAttribute ;
+                              edo:hasTypedValue edo:stringValue ;
+                              edo:hasValueCardinality edo:singleValue .
 
 ###  https://w3id.org/energy-domain/edo#SupportRegion
-:SupportRegion rdf:type owl:Class ;
-               rdfs:subClassOf :ModelLocationPoint ;
+edo:SupportRegion rdf:type owl:Class ;
+               rdfs:subClassOf edo:ModelLocationPoint ;
                dcterms:identifier "SupportRegion" ;
                skos:definition "A specific region used to define the support location of the components within a 3D model."@en ;
                skos:prefLabel "Support Region"@en ,
                               "Região de suporte no Modelo"@pt-br .
 
 ###  https://w3id.org/energy-domain/edo#SurfaceEquipment
-:SurfaceEquipment rdf:type owl:Class ;
-                  rdfs:subClassOf :Equipment ;
+edo:SurfaceEquipment rdf:type owl:Class ;
+                  rdfs:subClassOf edo:Equipment ;
                   dcterms:identifier "SurfaceEquipment" .
 
 
 ###  https://w3id.org/energy-domain/edo#TPT
-:TPT rdf:type owl:Class ;
-     rdfs:subClassOf :Sensor ;
+edo:TPT rdf:type owl:Class ;
+     rdfs:subClassOf edo:Sensor ;
      dcterms:identifier "TPT" .
 
 
 ###  https://w3id.org/energy-domain/edo#TapeLayer
-:TapeLayer rdf:type owl:Class ;
-           rdfs:subClassOf :WoundLayer ;
+edo:TapeLayer rdf:type owl:Class ;
+           rdfs:subClassOf edo:WoundLayer ;
            dcterms:identifier "TapeLayer" ;
            skos:definition "A layer within the structure of a subsea flexible pipe composed of tape-like materials. This layer is designed to provide additional reinforcement and protection. Typically made from high-strength polymers or other durable materials, the tape layer contributes to the pipe’s overall flexibility, structural integrity, and resistance to external environmental factors. Engineered for harsh underwater conditions, it helps maintain the performance and durability of the flexible pipe system."@en ;
            skos:prefLabel "Camada de Fita"@pt-br ,
@@ -6373,21 +6372,21 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#TapesQuantity
-:TapesQuantity rdf:type owl:Class ;
-               rdfs:subClassOf :DomainAttribute ;
+edo:TapesQuantity rdf:type owl:Class ;
+               rdfs:subClassOf edo:DomainAttribute ;
                dcterms:accessRights "PUBLIC" ;
                dcterms:identifier "TapesQuantity" ;
                skos:definition "Number of tapes applied within the structure, influencing factors such as insulation, protection, and reinforcement. "@en ;
                skos:prefLabel "Quantidade de fitas"@pt-br ,
                               "Tapes Quantity"@en ;
-               :hasAttributeScope :InstanceLevelAttribute ;
-               :hasTypedValue :intValue ;
-               :hasValueCardinality :singleValue .
+               edo:hasAttributeScope edo:InstanceLevelAttribute ;
+               edo:hasTypedValue edo:intValue ;
+               edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#TechnicalDiscipline
-:TechnicalDiscipline rdf:type owl:Class ;
-                     rdfs:subClassOf :ElementClassification ;
+edo:TechnicalDiscipline rdf:type owl:Class ;
+                     rdfs:subClassOf edo:ElementClassification ;
                      rdfs:comment "Superclass for all technical engineering disciplines."@en ;
                      rdfs:label "Disciplina Técnica"@pt-br ,
                                 "Technical Discipline"@en ;
@@ -6396,212 +6395,212 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#TechnicalNotes
-:TechnicalNotes rdf:type owl:Class ;
-                rdfs:subClassOf :DomainAttribute ;
+edo:TechnicalNotes rdf:type owl:Class ;
+                rdfs:subClassOf edo:DomainAttribute ;
                 dcterms:accessRights "PUBLIC" ;
                 dcterms:identifier "TechnicalNotes" ;
                 skos:definition "A field used to provide additional technical information or clarifications that may not be covered by other specific properties, to support a comprehensive understanding of the material’s behavior and suitability."@en ;
                 skos:prefLabel "Notas Técnicas"@pt-br ,
                                "Technical Notes"@en ;
-                :hasAttributeScope :InstanceLevelAttribute ,
-                                   :TypeLevelAttribute ;
-                :hasTypedValue :stringValue ;
-                :hasValueCardinality :singleValue .
+                edo:hasAttributeScope edo:InstanceLevelAttribute ,
+                                   edo:TypeLevelAttribute ;
+                edo:hasTypedValue edo:stringValue ;
+                edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#TemperatureSensor
-:TemperatureSensor rdf:type owl:Class ;
-                   rdfs:subClassOf :Sensor ;
+edo:TemperatureSensor rdf:type owl:Class ;
+                   rdfs:subClassOf edo:Sensor ;
                    dcterms:identifier "TemperatureSensor" .
 
 
 ###  https://w3id.org/energy-domain/edo#TensileArmour
-:TensileArmour rdf:type owl:Class ;
-               rdfs:subClassOf :WireLayer ;
+edo:TensileArmour rdf:type owl:Class ;
+               rdfs:subClassOf edo:WireLayer ;
                dcterms:identifier "TensileArmour" ;
                skos:definition "Protective layer designed to withstand high tensile stresses and mechanical loads, Tensile Armour is composed of high-strength steel wires or reinforced materials arranged in a helical configuration around the riser. It provides essential resistance to tension and shields the inner layers from mechanical damage and wear, ensuring the riser's integrity and durability during installation and operation in extreme underwater conditions."@en ;
                skos:prefLabel "Armadura de Tração"@pt-br ,
                               "Tensile Armour"@en ;
-               :hasAttribute :TensileWireLayAngle ,
-                             :TensileWiresCount ;
-               :ifc_equivalentClass "IfcPipeSegment" ;
-               :ifc_objectType "TensileArmour" ;
-               :ifc_predefinedType "USERDEFINED" .
+               edo:hasAttribute edo:TensileWireLayAngle ,
+                             edo:TensileWiresCount ;
+               edo:ifc_equivalentClass "IfcPipeSegment" ;
+               edo:ifc_objectType "TensileArmour" ;
+               edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#TensileArmourAnnulusCondition
-:TensileArmourAnnulusCondition rdf:type owl:Class ;
-                               rdfs:subClassOf :BendingStiffnessAttribute ;
+edo:TensileArmourAnnulusCondition rdf:type owl:Class ;
+                               rdfs:subClassOf edo:BendingStiffnessAttribute ;
                                dcterms:accessRights "PUBLIC" ;
                                dcterms:identifier "TensileArmourAnnulusCondition" ;
                                skos:definition "Condição do anular das amarduras de tração, Alagado ou Seco"@pt-br ,
                                                "Indicates the condition of the annulus in the tensile armour layer, which refers to the space between the tensile armour and other layers."@en ;
                                skos:prefLabel "Condição do Anular das Armaduras de Tração"@pt-br ,
                                               "Tensile Armour Annulus Condition"@en ;
-                               :hasAttributeScope :TypeLevelAttribute ;
-                               :hasTypedValue :stringValue ;
-                               :hasValueCardinality :singleValue .
+                               edo:hasAttributeScope edo:TypeLevelAttribute ;
+                               edo:hasTypedValue edo:stringValue ;
+                               edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#TensileArmourFreeAnnulusVolume
-:TensileArmourFreeAnnulusVolume rdf:type owl:Class ;
-                                rdfs:subClassOf :DomainAttribute ;
+edo:TensileArmourFreeAnnulusVolume rdf:type owl:Class ;
+                                rdfs:subClassOf edo:DomainAttribute ;
                                 dcterms:accessRights "PUBLIC" ;
                                 dcterms:identifier "TensileArmourFreeAnnulusVolume" ;
                                 skos:definition "Indicates the available volume within the annulus of the tensile armour layer that is not occupied by material."@en ;
                                 skos:prefLabel "Tensile Armour Free Annulus Volume"@en ,
                                                "Volume livre do anular das armaduras de tração"@pt-br ;
-                                :hasAttributeScope :TypeLevelAttribute ;
-                                :hasTypedValue :floatValue ;
-                                :hasValueCardinality :singleValue .
+                                edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                edo:hasTypedValue edo:floatValue ;
+                                edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#TensileWireLayAngle
-:TensileWireLayAngle rdf:type owl:Class ;
-                     rdfs:subClassOf :DomainAttribute ;
+edo:TensileWireLayAngle rdf:type owl:Class ;
+                     rdfs:subClassOf edo:DomainAttribute ;
                      dcterms:accessRights "PUBLIC" ;
                      dcterms:identifier "TensileWireLayAngle" ;
                      skos:definition "Refers to the angle formed between the individual tensile wires and the longitudinal axis of the flexible pipe. This angle determines how the wires are arranged around the pipe, influencing its mechanical properties and performance under load."@en ;
                      skos:prefLabel "Tensile Wire Lay Angle"@en ,
                                     "Ângulo de Enrolamento dos Arames sob Tração"@pt-br ;
-                     :hasAttributeScope :InstanceLevelAttribute ;
-                     :hasTypedValue :floatValue ;
-                     :hasValueCardinality :singleValue .
+                     edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                     edo:hasTypedValue edo:floatValue ;
+                     edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#TensileWiresCount
-:TensileWiresCount rdf:type owl:Class ;
-                   rdfs:subClassOf :DomainAttribute ;
+edo:TensileWiresCount rdf:type owl:Class ;
+                   rdfs:subClassOf edo:DomainAttribute ;
                    dcterms:accessRights "PUBLIC" ;
                    dcterms:identifier "TensileWiresCount" ;
                    skos:definition "Indicates the total number of tensile wires in the layer, which contributes to the mechanical strength and load-bearing capacity of the flexible pipe."@en ;
                    skos:prefLabel "Quantidade de Arames de Tração"@pt-br ,
                                   "Tensile Wires Count"@en ;
-                   :hasAttributeScope :InstanceLevelAttribute ;
-                   :hasTypedValue :intValue ;
-                   :hasValueCardinality :singleValue .
+                   edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                   edo:hasTypedValue edo:intValue ;
+                   edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#TensionerPadsMaterial
-:TensionerPadsMaterial rdf:type owl:Class ;
-                       rdfs:subClassOf :CrushingFrictionCoefficientTighteningAttribute ,
-                                       :CrushingMaximumAllowableTighteningAttribute ;
+edo:TensionerPadsMaterial rdf:type owl:Class ;
+                       rdfs:subClassOf edo:CrushingFrictionCoefficientTighteningAttribute ,
+                                       edo:CrushingMaximumAllowableTighteningAttribute ;
                        dcterms:accessRights "PUBLIC" ;
                        dcterms:identifier "TensionerPadsMaterial" ;
                        skos:definition "Indicates the fabrication material used for the tensioner pads. This property is important for assessing the durability, friction, and wear resistance of the pads, ensuring they perform effectively under operational conditions."@en ,
                                        "Nome do material da sapata do tensionador (Por exemplo, Carbon Steel)"@pt-br ;
                        skos:prefLabel "Material das Sapatas do Tensionador"@pt-br ,
                                       "Tensioner Pads Material"@en ;
-                       :hasAttributeScope :TypeLevelAttribute ;
-                       :hasTypedValue :stringValue ;
-                       :hasValueCardinality :singleValue .
+                       edo:hasAttributeScope edo:TypeLevelAttribute ;
+                       edo:hasTypedValue edo:stringValue ;
+                       edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#TensionerPadsOpeningAngle
-:TensionerPadsOpeningAngle rdf:type owl:Class ;
-                           rdfs:subClassOf :CrushingFrictionCoefficientTighteningAttribute ,
-                                           :CrushingMaximumAllowableTighteningAttribute ;
+edo:TensionerPadsOpeningAngle rdf:type owl:Class ;
+                           rdfs:subClassOf edo:CrushingFrictionCoefficientTighteningAttribute ,
+                                           edo:CrushingMaximumAllowableTighteningAttribute ;
                            dcterms:accessRights "PUBLIC" ;
                            dcterms:identifier "TensionerPadsOpeningAngle" ;
                            skos:definition "Defines the opening angle of the tensioner pads. This angle is crucial for determining how the pads make contact with the surface, affecting the distribution of force and the overall efficiency of the tightening process. Proper control of this angle ensures effective load application and surface protection during operation."@en ;
                            skos:prefLabel "Tensioner Pads Opening Angle"@en ,
                                           "Ângulo de Abertura das Sapatas do Tensionador"@pt-br ;
-                           :hasAttributeScope :TypeLevelAttribute ;
-                           :hasTypedValue :intValue ;
-                           :hasValueCardinality :singleValue .
+                           edo:hasAttributeScope edo:TypeLevelAttribute ;
+                           edo:hasTypedValue edo:intValue ;
+                           edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#TensionerPadsShape
-:TensionerPadsShape rdf:type owl:Class ;
-                    rdfs:subClassOf :CrushingFrictionCoefficientTighteningAttribute ,
-                                    :CrushingMaximumAllowableTighteningAttribute ;
+edo:TensionerPadsShape rdf:type owl:Class ;
+                    rdfs:subClassOf edo:CrushingFrictionCoefficientTighteningAttribute ,
+                                    edo:CrushingMaximumAllowableTighteningAttribute ;
                     dcterms:accessRights "PUBLIC" ;
                     dcterms:identifier "TensionerPadsShape" ;
                     skos:definition "Disposição geométrica da sapata (Por exemplo \"V\")"@pt-br ,
                                     "Specifies the geometric shape of the tensioner pads. The shape affects the contact area, frictional performance, and overall effectiveness of the tightening process, influencing how forces are applied and distributed."@en ;
                     skos:prefLabel "Forma das Sapatas do Tensionador"@pt-br ,
                                    "Tensioner Pads Shape"@en ;
-                    :hasAttributeScope :TypeLevelAttribute ;
-                    :hasTypedValue :stringValue ;
-                    :hasValueCardinality :singleValue .
+                    edo:hasAttributeScope edo:TypeLevelAttribute ;
+                    edo:hasTypedValue edo:stringValue ;
+                    edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#TensionerTracksQuantity
-:TensionerTracksQuantity rdf:type owl:Class ;
-                         rdfs:subClassOf :CrushingFrictionCoefficientTighteningAttribute ,
-                                         :CrushingMaximumAllowableTighteningAttribute ;
+edo:TensionerTracksQuantity rdf:type owl:Class ;
+                         rdfs:subClassOf edo:CrushingFrictionCoefficientTighteningAttribute ,
+                                         edo:CrushingMaximumAllowableTighteningAttribute ;
                          dcterms:accessRights "PUBLIC" ;
                          dcterms:identifier "TensionerTracksQuantity" ;
                          skos:definition "Indicates the quantity of tensioner tracks. This value is important for understanding the distribution of tightening forces and how evenly the load is applied across the structure during the tightening process."@en ,
                                          "Quantidade de lagartas do tensionador (Por exemplo, 4)"@pt-br ;
                          skos:prefLabel "Quantidade de Lagartas do Tensionador"@pt-br ,
                                         "Tensioner Tracks Quantity"@en ;
-                         :hasAttributeScope :TypeLevelAttribute ;
-                         :hasTypedValue :intValue ;
-                         :hasValueCardinality :singleValue .
+                         edo:hasAttributeScope edo:TypeLevelAttribute ;
+                         edo:hasTypedValue edo:intValue ;
+                         edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#TestBase
-:TestBase rdf:type owl:Class ;
-          rdfs:subClassOf :TestEquipment ;
+edo:TestBase rdf:type owl:Class ;
+          rdfs:subClassOf edo:TestEquipment ;
           dcterms:identifier "TestBase" .
 
 
 ###  https://w3id.org/energy-domain/edo#TestConditions
-:TestConditions rdf:type owl:Class ;
-                rdfs:subClassOf :BendingStiffnessAttribute ,
-                                :CrushingFrictionCoefficientTighteningAttribute ,
-                                :CrushingMaximumAllowableTensionAttribute ,
-                                :CrushingMaximumAllowableTighteningAttribute ,
-                                :LayingMinimumRadiusTableAttribute ;
+edo:TestConditions rdf:type owl:Class ;
+                rdfs:subClassOf edo:BendingStiffnessAttribute ,
+                                edo:CrushingFrictionCoefficientTighteningAttribute ,
+                                edo:CrushingMaximumAllowableTensionAttribute ,
+                                edo:CrushingMaximumAllowableTighteningAttribute ,
+                                edo:LayingMinimumRadiusTableAttribute ;
                 dcterms:accessRights "PUBLIC" ;
                 dcterms:identifier "TestConditions" ;
                 skos:definition "Descrição completa das condições para a execução do ensaio"@pt-br ,
                                 "Specifies unstructured complementary information regarding the conditions under which a test is performed. This property may include additional details such as temperature, pressure, load, or other factors that could influence the test results, providing context for accurate interpretation of performance assessments."@en ;
                 skos:prefLabel "Condições de Teste"@pt-br ,
                                "Test Conditions"@en ;
-                :hasAttributeScope :TypeLevelAttribute ;
-                :hasTypedValue :stringValue ;
-                :hasValueCardinality :singleValue .
+                edo:hasAttributeScope edo:TypeLevelAttribute ;
+                edo:hasTypedValue edo:stringValue ;
+                edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#TestEquipment
-:TestEquipment rdf:type owl:Class ;
-               rdfs:subClassOf :SurfaceEquipment ;
+edo:TestEquipment rdf:type owl:Class ;
+               rdfs:subClassOf edo:SurfaceEquipment ;
                dcterms:identifier "TestEquipment" .
 
 
 ###  https://w3id.org/energy-domain/edo#ThermalConductivityCoefficient
-:ThermalConductivityCoefficient rdf:type owl:Class ;
-                                rdfs:subClassOf :DomainAttribute ;
+edo:ThermalConductivityCoefficient rdf:type owl:Class ;
+                                rdfs:subClassOf edo:DomainAttribute ;
                                 dcterms:accessRights "PUBLIC" ;
                                 dcterms:identifier "ThermalConductivityCoefficient" ;
                                 skos:definition "Coeficiente de Condutividade Térmica do material (Obs. Para materiais compósitos, indicar o coefitiente no sentido longitudinal das fibras)"@pt-br ,
                                                 "Indicates the material's ability to conduct heat, measured as the rate at which heat passes through the material under a temperature gradient. This property is important for assessing how the material handles heat transfer in subsea environments, ensuring it can maintain performance under varying thermal conditions."@en ;
                                 skos:prefLabel "Coeficiente de Condutividade Térmica"@pt-br ,
                                                "Thermal Conductivity Coefficient"@en ;
-                                :hasAttributeScope :TypeLevelAttribute ;
-                                :hasTypedValue :floatValue ;
-                                :hasValueCardinality :singleValue .
+                                edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                edo:hasTypedValue edo:floatValue ;
+                                edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#ThermalExchangeCoefficientFlooded
-:ThermalExchangeCoefficientFlooded rdf:type owl:Class ;
-                                   rdfs:subClassOf :DomainAttribute ;
+edo:ThermalExchangeCoefficientFlooded rdf:type owl:Class ;
+                                   rdfs:subClassOf edo:DomainAttribute ;
                                    dcterms:accessRights "PUBLIC" ;
                                    dcterms:identifier "ThermalExchangeCoefficientFlooded" ;
                                    skos:definition "Coeficiente de troca térmica na temperatura máxima de projeto no interior, na temperatura da profundidade máxima especificada da água no exterior, com os anulares de isolamento e das armadura de tração alagados, no final da vida útil."@pt-br ,
                                                    "Indicates the rate at which heat is transferred through a material or component in flooded conditions. This property is essential for assessing the material's thermal performance, influencing its ability to manage heat effectively in operational scenarios where it is exposed to fluid filling."@en ;
                                    skos:prefLabel "Coeficiente de Troca Térmica em Condição Alagada"@pt-br ,
                                                   "Thermal Exchange Coefficient Flooded"@en ;
-                                   :hasAttributeScope :TypeLevelAttribute ;
-                                   :hasTypedValue :floatValue ;
-                                   :hasValueCardinality :singleValue .
+                                   edo:hasAttributeScope edo:TypeLevelAttribute ;
+                                   edo:hasTypedValue edo:floatValue ;
+                                   edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#ThermalPower
-:ThermalPower rdf:type owl:Class ;
-              rdfs:subClassOf :Domain ;
+edo:ThermalPower rdf:type owl:Class ;
+              rdfs:subClassOf edo:Domain ;
               rdfs:label "Energia Térmica"@pt-br ,
                          "Thermal Power"@en ;
               skos:definition "Energy production from fossil fuels (coal, natural gas) through thermal conversion."@en ,
@@ -6609,73 +6608,73 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#ThreadPitch
-:ThreadPitch rdf:type owl:Class ;
-             rdfs:subClassOf :DomainAttribute ;
+edo:ThreadPitch rdf:type owl:Class ;
+             rdfs:subClassOf edo:DomainAttribute ;
              dcterms:accessRights "PUBLIC" ;
              dcterms:identifier "ThreadPitch" ;
              skos:definition "The distance between adjacent thread crests, measured along the thread's axis, determining the threading's fineness or coarseness."@en ;
              skos:prefLabel "Passo da Rosca"@pt-br ,
                             "Thread Pitch"@en ;
-             :hasAttributeScope :InstanceLevelAttribute ;
-             :hasTypedValue :floatValue ;
-             :hasValueCardinality :singleValue .
+             edo:hasAttributeScope edo:InstanceLevelAttribute ;
+             edo:hasTypedValue edo:floatValue ;
+             edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#ThreadStandard
-:ThreadStandard rdf:type owl:Class ;
-                rdfs:subClassOf :DomainAttribute ;
+edo:ThreadStandard rdf:type owl:Class ;
+                rdfs:subClassOf edo:DomainAttribute ;
                 dcterms:accessRights "PUBLIC" ;
                 dcterms:identifier "ThreadStandard" ;
                 skos:definition "The standard specification governing the design and dimensions of threads used in the component, ensuring compatibility and interchangeability."@en ;
                 skos:prefLabel "Padrão de Rosca"@pt-br ,
                                "Thread Standard"@en ;
-                :hasAttributeScope :InstanceLevelAttribute ;
-                :hasTypedValue :stringValue ;
-                :hasValueCardinality :singleValue .
+                edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                edo:hasTypedValue edo:stringValue ;
+                edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#ThreadsPerInch
-:ThreadsPerInch rdf:type owl:Class ;
-                rdfs:subClassOf :DomainAttribute ;
+edo:ThreadsPerInch rdf:type owl:Class ;
+                rdfs:subClassOf edo:DomainAttribute ;
                 dcterms:accessRights "PUBLIC" ;
                 dcterms:identifier "ThreadsPerInch" ;
                 skos:definition "Threads per Inch. Indicates the number of threads present in one inch of the bolt"@en ;
                 skos:prefLabel "Fios por Polegada"@pt-br ,
                                "Threads Per Inch"@en ;
-                :hasAttributeScope :InstanceLevelAttribute ;
-                :hasTypedValue :floatValue ;
-                :hasValueCardinality :singleValue .
+                edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                edo:hasTypedValue edo:floatValue ;
+                edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#TieIn
-:TieIn rdf:type owl:Class ;
-       rdfs:subClassOf :PressureComponent ;
+edo:TieIn rdf:type owl:Class ;
+       rdfs:subClassOf edo:PressureComponent ;
        dcterms:identifier "TieIn" .
 
 
 ###  https://w3id.org/energy-domain/edo#TieInEquipment
-:TieInEquipment rdf:type owl:Class ;
-                rdfs:subClassOf :FlowControlModule ;
+edo:TieInEquipment rdf:type owl:Class ;
+                rdfs:subClassOf edo:FlowControlModule ;
                 dcterms:identifier "TieInEquipment" .
 
 
 ###  https://w3id.org/energy-domain/edo#Timestamp
-:Timestamp rdf:type owl:Class ;
-           rdfs:subClassOf :JustificationAttribute ,
-                           :Registry_GUIDAttribute ,
-                           :StatusAttribute ;
+edo:Timestamp rdf:type owl:Class ;
+           rdfs:subClassOf edo:JustificationAttribute ,
+                           edo:Registry_GUIDAttribute ,
+                           edo:StatusAttribute ;
            dcterms:accessRights "PUBLIC" ;
            dcterms:identifier "Timestamp" ;
            skos:definition "Exact date and time, providing a precise reference for tracking when an event or action occurred within the system."@en ;
            skos:prefLabel "Timestamp"@en ;
-           :hasAttributeScope :InstanceLevelAttribute ;
-           :hasTypedValue :dateTimeValue ;
-           :hasValueCardinality :singleValue .
+           edo:hasAttributeScope edo:InstanceLevelAttribute ;
+           edo:hasTypedValue edo:dateTimeValue ;
+           edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#TopBendStiffener
-:TopBendStiffener rdf:type owl:Class ;
-                  rdfs:subClassOf :BendStiffener ;
+edo:TopBendStiffener rdf:type owl:Class ;
+                  rdfs:subClassOf edo:BendStiffener ;
                   dcterms:identifier "TopBendStiffener" ;
                   skos:altLabel "Curvature Stiffener"@en ,
                                 "Stiffener"@en ,
@@ -6683,37 +6682,37 @@ rdf:value rdf:type owl:DatatypeProperty .
                   skos:definition "Designed to support and stabilize the riser where it transitions from the seabed to the floating platform or vessel, the Top Bend Stiffener is composed of high-strength materials such as steel or composites. It helps prevent excessive bending, distributes mechanical loads, and enhances flexibility management, ensuring the riser's structural integrity and performance during installation and operation in dynamic offshore conditions."@en ;
                   skos:prefLabel "Enrijecedor de Curvatura de Topo"@pt-br ,
                                  "Top Bend Stiffener"@en ;
-                  :ifc_equivalentClass "IfcPipeFitting" ;
-                  :ifc_objectType "TopBendStiffener" .
+                  edo:ifc_equivalentClass "IfcPipeFitting" ;
+                  edo:ifc_objectType "TopBendStiffener" .
 
 
 ###  https://w3id.org/energy-domain/edo#TopsideConnectionPoint
-:TopsideConnectionPoint rdf:type owl:Class ;
-                        rdfs:subClassOf :LogicalConnection ;
+edo:TopsideConnectionPoint rdf:type owl:Class ;
+                        rdfs:subClassOf edo:LogicalConnection ;
                         dcterms:identifier "TopsideConnectionPoint" ;
                         skos:definition "Designed to connect the riser to the floating platform or vessel, the Topside Connection Point is a crucial component that ensures a secure and reliable interface between the riser and the topside facilities. Composed of high-strength materials, this connector is engineered to handle the mechanical loads and dynamic conditions of offshore environments. It facilitates the transfer of fluids and provides structural stability, playing a key role in maintaining the overall integrity and functionality of the riser system."@en ;
                         skos:prefLabel "Ponto de Conexão de Topo"@pt-br ,
                                        "Topside Connection Point"@en ;
-                        :ifc_equivalentClass "IfcPipeFitting" ;
-                        :ifc_objectType "TopsideConnectionPoint" ;
-                        :ifc_predefinedType "USERDEFINED" .
+                        edo:ifc_equivalentClass "IfcPipeFitting" ;
+                        edo:ifc_objectType "TopsideConnectionPoint" ;
+                        edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#TopsideEquipment
-:TopsideEquipment rdf:type owl:Class ;
-                  rdfs:subClassOf :SurfaceEquipment ;
+edo:TopsideEquipment rdf:type owl:Class ;
+                  rdfs:subClassOf edo:SurfaceEquipment ;
                   dcterms:identifier "TopsideEquipment" .
 
 
 ###  https://w3id.org/energy-domain/edo#TorpedoPile
-:TorpedoPile rdf:type owl:Class ;
-             rdfs:subClassOf :Pile ;
+edo:TorpedoPile rdf:type owl:Class ;
+             rdfs:subClassOf edo:Pile ;
              dcterms:identifier "TorpedoPile" .
 
 
 ###  https://w3id.org/energy-domain/edo#TransportLineSegment
-:TransportLineSegment rdf:type owl:Class ;
-                      rdfs:subClassOf :LinearObject ;
+edo:TransportLineSegment rdf:type owl:Class ;
+                      rdfs:subClassOf edo:LinearObject ;
                       dcterms:identifier "TransportLineSegment" ;
                       skos:definition "Line for conducting some type of flow."@en ;
                       skos:prefLabel "Segmento de Linha de Transporte"@pt-br ,
@@ -6721,8 +6720,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#Transportation
-:Transportation rdf:type owl:Class ;
-                rdfs:subClassOf :LifecyclePhase ;
+edo:Transportation rdf:type owl:Class ;
+                rdfs:subClassOf edo:LifecyclePhase ;
                 rdfs:label "Transportation"@en ,
                            "Transporte"@pt-br ;
                 skos:definition "Logistics and transport of materials and equipment to the construction or installation site."@en ,
@@ -6730,44 +6729,44 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#TreeCap
-:TreeCap rdf:type owl:Class ;
-         rdfs:subClassOf :FlowControlModule ;
+edo:TreeCap rdf:type owl:Class ;
+         rdfs:subClassOf edo:FlowControlModule ;
          dcterms:identifier "TreeCap" .
 
 
 ###  https://w3id.org/energy-domain/edo#TreeRunningTool
-:TreeRunningTool rdf:type owl:Class ;
-                 rdfs:subClassOf :RunningTool ;
+edo:TreeRunningTool rdf:type owl:Class ;
+                 rdfs:subClassOf edo:RunningTool ;
                  dcterms:identifier "TreeRunningTool" .
 
 
 ###  https://w3id.org/energy-domain/edo#TrianglePlate
-:TrianglePlate rdf:type owl:Class ;
-               rdfs:subClassOf :MooringAccessory ;
+edo:TrianglePlate rdf:type owl:Class ;
+               rdfs:subClassOf edo:MooringAccessory ;
                dcterms:identifier "TrianglePlate" .
 
 
 ###  https://w3id.org/energy-domain/edo#Tubing
-:Tubing rdf:type owl:Class ;
-        rdfs:subClassOf :FunctionLine ;
+edo:Tubing rdf:type owl:Class ;
+        rdfs:subClassOf edo:FunctionLine ;
         dcterms:identifier "Tubing" .
 
 
 ###  https://w3id.org/energy-domain/edo#TubingHanger
-:TubingHanger rdf:type owl:Class ;
-              rdfs:subClassOf :PressureComponent ;
+edo:TubingHanger rdf:type owl:Class ;
+              rdfs:subClassOf edo:PressureComponent ;
               dcterms:identifier "TubingHanger" .
 
 
 ###  https://w3id.org/energy-domain/edo#TubingHangerRunningTool
-:TubingHangerRunningTool rdf:type owl:Class ;
-                         rdfs:subClassOf :RunningTool ;
+edo:TubingHangerRunningTool rdf:type owl:Class ;
+                         rdfs:subClassOf edo:RunningTool ;
                          dcterms:identifier "TubingHangerRunningTool" .
 
 
 ###  https://w3id.org/energy-domain/edo#TypeLevelAttribute
-:TypeLevelAttribute rdf:type owl:Class ;
-                    rdfs:subClassOf :AttributeScope ;
+edo:TypeLevelAttribute rdf:type owl:Class ;
+                    rdfs:subClassOf edo:AttributeScope ;
                     rdfs:comment "Attribute common to all items of the same type."@en ;
                     rdfs:label "Atributo de Tipo"@pt-br ,
                                "Type-Level Attribute"@en ;
@@ -6776,164 +6775,164 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#TypedValue
-:TypedValue rdf:type owl:Class ;
-            rdfs:subClassOf :DomainAuxiliarClass ;
+edo:TypedValue rdf:type owl:Class ;
+            rdfs:subClassOf edo:DomainAuxiliarClass ;
             rdfs:comment "Superclass for values constrained to a specific XSD datatype."@en ;
             rdfs:label "Typed Value"@en .
 
 
 ###  https://w3id.org/energy-domain/edo#UNSBoltSet
-:UNSBoltSet rdf:type owl:Class ;
-            rdfs:subClassOf :BoltSet ;
+edo:UNSBoltSet rdf:type owl:Class ;
+            rdfs:subClassOf edo:BoltSet ;
             dcterms:identifier "UNSBoltSet" ;
             skos:definition "A set of bolts conforming to the Unified Numbering System (UNS) standard, ensuring material consistency and reliability in subsea applications."@en ;
             skos:prefLabel "Conjunto de Parafusos UNS"@pt-br ,
                            "UNS Bolt Set"@en ;
-            :hasAttribute :NominalDiameter ,
-                          :PitchToleranceClass ,
-                          :ThreadStandard ,
-                          :ThreadsPerInch ;
-            :ifc_equivalentClass "IfcMechanicalFastener" ;
-            :ifc_objectType "UNSBoltSet" ;
-            :ifc_predefinedType "USERDEFINED" .
+            edo:hasAttribute edo:NominalDiameter ,
+                          edo:PitchToleranceClass ,
+                          edo:ThreadStandard ,
+                          edo:ThreadsPerInch ;
+            edo:ifc_equivalentClass "IfcMechanicalFastener" ;
+            edo:ifc_objectType "UNSBoltSet" ;
+            edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#UNSStudSet
-:UNSStudSet rdf:type owl:Class ;
-            rdfs:subClassOf :StudSet ;
+edo:UNSStudSet rdf:type owl:Class ;
+            rdfs:subClassOf edo:StudSet ;
             dcterms:identifier "UNSStudSet" ;
             skos:definition "UNS stud sets are essential fastening components for subsea oil and gas components, tailored to securely join equipment parts. Each set comprises bolts, nuts, and washers, all in UNS sizing and crafted from high-strength, corrosion-resistant materials to endure the challenging subsea environment. These components provide robust fastening, ensuring structural integrity and leak prevention in end fittings. UNS stud sets are engineered to withstand high pressure and extreme temperatures, playing a vital role in the safety and longevity of subsea interconnections."@en ;
             skos:prefLabel "Conjunto de Estojos UNS"@pt-br ,
                            "UNS Stud Set"@en ;
-            :hasAttribute :PitchToleranceClass ,
-                          :ThreadStandard ,
-                          :ThreadsPerInch ;
-            :ifc_equivalentClass "IfcMechanicalFastener" ;
-            :ifc_objectType "UNSStudSet" ;
-            :ifc_predefinedType "USERDEFINED" .
+            edo:hasAttribute edo:PitchToleranceClass ,
+                          edo:ThreadStandard ,
+                          edo:ThreadsPerInch ;
+            edo:ifc_equivalentClass "IfcMechanicalFastener" ;
+            edo:ifc_objectType "UNSStudSet" ;
+            edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#UTA
-:UTA rdf:type owl:Class ;
-     rdfs:subClassOf :SubseaEquipment ;
+edo:UTA rdf:type owl:Class ;
+     rdfs:subClassOf edo:SubseaEquipment ;
      dcterms:identifier "UTA" .
 
 
 ###  https://w3id.org/energy-domain/edo#UTM
-:UTM rdf:type owl:Class ;
-     rdfs:subClassOf :LineTerminationModule ;
+edo:UTM rdf:type owl:Class ;
+     rdfs:subClassOf edo:LineTerminationModule ;
      dcterms:identifier "UTM" .
 
 
 ###  https://w3id.org/energy-domain/edo#UltTensStrAlongFibers
-:UltTensStrAlongFibers rdf:type owl:Class ;
-                       rdfs:subClassOf :DomainAttribute ;
+edo:UltTensStrAlongFibers rdf:type owl:Class ;
+                       rdfs:subClassOf edo:DomainAttribute ;
                        dcterms:accessRights "PUBLIC" ;
                        dcterms:identifier "UltTensStrAlongFibers" ;
                        skos:definition "Indicates the maximum tensile stress a material can withstand along the direction of its fibers before breaking. This property is crucial for assessing the strength of fiber-reinforced materials, ensuring they can handle tensile loads effectively in the direction of fiber alignment."@en ;
                        skos:prefLabel "Tensão máxima de tração longitudinalmente às fibras"@pt-br ,
                                       "Ultimate Tensile Strength Along Fibers"@en ;
-                       :hasAttributeScope :TypeLevelAttribute ;
-                       :hasTypedValue :floatValue ;
-                       :hasValueCardinality :singleValue .
+                       edo:hasAttributeScope edo:TypeLevelAttribute ;
+                       edo:hasTypedValue edo:floatValue ;
+                       edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#UltTensStrPerpendFibers
-:UltTensStrPerpendFibers rdf:type owl:Class ;
-                         rdfs:subClassOf :DomainAttribute ;
+edo:UltTensStrPerpendFibers rdf:type owl:Class ;
+                         rdfs:subClassOf edo:DomainAttribute ;
                          dcterms:accessRights "PUBLIC" ;
                          dcterms:identifier "UltTensStrPerpendFibers" ;
                          skos:definition "Indicates the maximum tensile stress a material can withstand when applied perpendicular to the direction of its fibers before breaking. This property is important for evaluating the strength and durability of fiber-reinforced materials under tensile loads that are not aligned with the fibers, providing insights into their performance in various loading conditions."@en ;
                          skos:prefLabel "Tensão máxima de tração perpendicularmente às fibras"@pt-br ,
                                         "Ultimate Tensile Strength Perpendicular To Fibers"@en ;
-                         :hasAttributeScope :TypeLevelAttribute ;
-                         :hasTypedValue :floatValue ;
-                         :hasValueCardinality :singleValue .
+                         edo:hasAttributeScope edo:TypeLevelAttribute ;
+                         edo:hasTypedValue edo:floatValue ;
+                         edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#UltimateTensileStress
-:UltimateTensileStress rdf:type owl:Class ;
-                       rdfs:subClassOf :DomainAttribute ;
+edo:UltimateTensileStress rdf:type owl:Class ;
+                       rdfs:subClassOf edo:DomainAttribute ;
                        dcterms:accessRights "PUBLIC" ;
                        dcterms:identifier "UltimateTensileStress" ;
                        skos:definition "Indicates the maximum stress a material can withstand while being stretched or pulled before breaking. This property is essential for evaluating the material's strength and determining its ability to perform under tensile loads without failure."@en ,
                                        "Tensão máxima de tração (Específica para Materiais Metálicos)"@pt-br ;
                        skos:prefLabel "Tensão Máxima de Tração"@pt-br ,
                                       "Ultimate Tensile Stress"@en ;
-                       :hasAttributeScope :TypeLevelAttribute ;
-                       :hasTypedValue :floatValue ;
-                       :hasValueCardinality :singleValue .
+                       edo:hasAttributeScope edo:TypeLevelAttribute ;
+                       edo:hasTypedValue edo:floatValue ;
+                       edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#UmbilicalComponent
-:UmbilicalComponent rdf:type owl:Class ;
-                    rdfs:subClassOf :DomainElement ;
+edo:UmbilicalComponent rdf:type owl:Class ;
+                    rdfs:subClassOf edo:DomainElement ;
                     dcterms:identifier "UmbilicalComponent" .
 
 
 ###  https://w3id.org/energy-domain/edo#UmbilicalLocation
-:UmbilicalLocation rdf:type owl:Class ;
-                   rdfs:subClassOf :Interconnection ;
+edo:UmbilicalLocation rdf:type owl:Class ;
+                   rdfs:subClassOf edo:Interconnection ;
                    dcterms:identifier "UmbilicalLocation" .
 
 
 ###  https://w3id.org/energy-domain/edo#UmbilicalSegment
-:UmbilicalSegment rdf:type owl:Class ;
-                  rdfs:subClassOf :TransportLineSegment ;
+edo:UmbilicalSegment rdf:type owl:Class ;
+                  rdfs:subClassOf edo:TransportLineSegment ;
                   dcterms:identifier "UmbilicalSegment" ;
-                  :ifc_equivalentClass "UmbilicalSegment" ;
-                  :ifc_objectType "IfcPipeSegment" ;
-                  :ifc_predefinedType "USERDEFINED" .
+                  edo:ifc_equivalentClass "UmbilicalSegment" ;
+                  edo:ifc_objectType "IfcPipeSegment" ;
+                  edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#UmbilicalSpan
-:UmbilicalSpan rdf:type owl:Class ;
-               rdfs:subClassOf :LineSpan ;
+edo:UmbilicalSpan rdf:type owl:Class ;
+               rdfs:subClassOf edo:LineSpan ;
                dcterms:identifier "UmbilicalSpan" .
 
 
 ###  https://w3id.org/energy-domain/edo#UnifilarDiagram
-:UnifilarDiagram rdf:type owl:Class ;
-                 rdfs:subClassOf :DomainAttribute ;
+edo:UnifilarDiagram rdf:type owl:Class ;
+                 rdfs:subClassOf edo:DomainAttribute ;
                  dcterms:accessRights "PUBLIC" ;
                  dcterms:identifier "UnifilarDiagram" ;
                  skos:definition "A simplified schematic illustrates the arrangement of flexible pipeline sections and their associated accessories, such as end fittings and clamps. This diagram shows how these sections and accessories are connected, providing a clear overview of the pipeline configuration without detailing internal structures. It is used to aid in planning, installation, and understanding of the flexible pipeline system by visualizing the main components and their positions."@en ;
                  skos:prefLabel "Código do Diagrama Unifilar"@pt-br ,
                                 "Unifilar Diagram"@en ;
-                 :hasAttributeScope :InstanceLevelAttribute ;
-                 :hasTypedValue :stringValue ;
-                 :hasValueCardinality :singleValue .
+                 edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                 edo:hasTypedValue edo:stringValue ;
+                 edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#UnifilarDiagramRev
-:UnifilarDiagramRev rdf:type owl:Class ;
-                    rdfs:subClassOf :DomainAttribute ;
+edo:UnifilarDiagramRev rdf:type owl:Class ;
+                    rdfs:subClassOf edo:DomainAttribute ;
                     dcterms:accessRights "PUBLIC" ;
                     dcterms:identifier "UnifilarDiagramRev" ;
                     skos:definition "Indicates the revision number of the unifilar diagram, reflecting updates or changes made to the arrangement of pipeline sections and their accessories. Each revision ensures that the latest configuration is accurately documented for installation and planning purposes."@en ;
                     skos:prefLabel "Número da Revisão do Diagrama Unifilar"@pt-br ,
                                    "Unifilar Diagram Revision"@en ;
-                    :hasAttributeScope :InstanceLevelAttribute ;
-                    :hasTypedValue :stringValue ;
-                    :hasValueCardinality :singleValue .
+                    edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                    edo:hasTypedValue edo:stringValue ;
+                    edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#UpperItubeDiameter
-:UpperItubeDiameter rdf:type owl:Class ;
-                    rdfs:subClassOf :DomainAttribute ;
+edo:UpperItubeDiameter rdf:type owl:Class ;
+                    rdfs:subClassOf edo:DomainAttribute ;
                     dcterms:accessRights "PUBLIC" ;
                     dcterms:identifier "UpperItubeDiameter" ;
                     skos:definition "Diameter of the upper section of the tube or pipe. This measurement is important for ensuring proper fit and compatibility with other components or connections. The diameter of the upper section affects the alignment and sealing capabilities of the assembly, and ensures that the tube or pipe meets the design and operational requirements for the installation or application."@en ;
                     skos:prefLabel "Diâmetro do I-TUBE superior"@pt-br ,
                                    "Upper I-tube Diameter"@en ;
-                    :hasAttributeScope :TypeLevelAttribute ;
-                    :hasTypedValue :floatValue ;
-                    :hasValueCardinality :singleValue .
+                    edo:hasAttributeScope edo:TypeLevelAttribute ;
+                    edo:hasTypedValue edo:floatValue ;
+                    edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#Upstream
-:Upstream rdf:type owl:Class ;
-          rdfs:subClassOf :OilAndGas ;
+edo:Upstream rdf:type owl:Class ;
+          rdfs:subClassOf edo:OilAndGas ;
           rdfs:label "Upstream"@en ,
                      "Upstream"@pt-br ;
           skos:definition "Oil & Gas sector covering exploration, drilling, and production of hydrocarbon resources."@en ,
@@ -6941,8 +6940,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#UtilityPipingEngineering
-:UtilityPipingEngineering rdf:type owl:Class ;
-                          rdfs:subClassOf :TechnicalDiscipline ;
+edo:UtilityPipingEngineering rdf:type owl:Class ;
+                          rdfs:subClassOf edo:TechnicalDiscipline ;
                           rdfs:label "Engenharia de Tubulação de Utilidades"@pt-br ,
                                      "Utility Piping Engineering"@en ;
                           skos:definition "Disciplina de engenharia focada no projeto de sistemas de tubulação para serviços de utilidades."@pt-br ,
@@ -6950,36 +6949,36 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#UtilizationFactor
-:UtilizationFactor rdf:type owl:Class ;
-                   rdfs:subClassOf :CrushingFrictionCoefficientTighteningAttribute ,
-                                   :CrushingMaximumAllowableTensionAttribute ,
-                                   :CrushingMaximumAllowableTighteningAttribute ;
+edo:UtilizationFactor rdf:type owl:Class ;
+                   rdfs:subClassOf edo:CrushingFrictionCoefficientTighteningAttribute ,
+                                   edo:CrushingMaximumAllowableTensionAttribute ,
+                                   edo:CrushingMaximumAllowableTighteningAttribute ;
                    dcterms:accessRights "PUBLIC" ;
                    dcterms:identifier "UtilizationFactor" ;
                    skos:definition "Represents the ratio used to determine the level of utilisation, indicating how much of the system’s capacity is being used under given conditions. This factor is crucial for assessing whether the structure operates within safe limits or approaching its maximum capacity."@en ;
                    skos:prefLabel "Fator de Utilização"@pt-br ,
                                   "Utilization Factor"@en ;
-                   :hasAttributeScope :TypeLevelAttribute ;
-                   :hasTypedValue :floatValue ;
-                   :hasValueCardinality :singleValue .
+                   edo:hasAttributeScope edo:TypeLevelAttribute ;
+                   edo:hasTypedValue edo:floatValue ;
+                   edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#VCM
-:VCM rdf:type owl:Class ;
-     rdfs:subClassOf :ConnectionModule ;
+edo:VCM rdf:type owl:Class ;
+     rdfs:subClassOf edo:ConnectionModule ;
      dcterms:identifier "VCM" .
 
 
 ###  https://w3id.org/energy-domain/edo#ValueCardinality
-:ValueCardinality rdf:type owl:Class ;
-                  rdfs:subClassOf :DomainAuxiliarClass ;
+edo:ValueCardinality rdf:type owl:Class ;
+                  rdfs:subClassOf edo:DomainAuxiliarClass ;
                   rdfs:comment "Superclass for constraints on the cardinality of values (single or multiple)."@en ;
                   rdfs:label "Value Cardinality"@en .
 
 
 ###  https://w3id.org/energy-domain/edo#ValueOrigin
-:ValueOrigin rdf:type owl:Class ;
-             rdfs:subClassOf :AttributeClassification ;
+edo:ValueOrigin rdf:type owl:Class ;
+             rdfs:subClassOf edo:AttributeClassification ;
              rdfs:comment "Indicates how the value is obtained."@en ;
              rdfs:label "Origem do Valor"@pt-br ,
                         "Value Origin"@en ;
@@ -6988,52 +6987,52 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#Valve
-:Valve rdf:type owl:Class ;
-       rdfs:subClassOf :PressureComponent ;
+edo:Valve rdf:type owl:Class ;
+       rdfs:subClassOf edo:PressureComponent ;
        dcterms:identifier "Valve" .
 
 
 ###  https://w3id.org/energy-domain/edo#Vessel
-:Vessel rdf:type owl:Class ;
-        rdfs:subClassOf :PressureComponent ;
+edo:Vessel rdf:type owl:Class ;
+        rdfs:subClassOf edo:PressureComponent ;
         dcterms:identifier "Vessel" .
 
 
 ###  https://w3id.org/energy-domain/edo#WaterIntake
-:WaterIntake rdf:type owl:Class ;
-             rdfs:subClassOf :SubseaEquipment ;
+edo:WaterIntake rdf:type owl:Class ;
+             rdfs:subClassOf edo:SubseaEquipment ;
              dcterms:identifier "WaterIntake" .
 
 
 ###  https://w3id.org/energy-domain/edo#WearBushing
-:WearBushing rdf:type owl:Class ;
-             rdfs:subClassOf :Accessory ;
+edo:WearBushing rdf:type owl:Class ;
+             rdfs:subClassOf edo:Accessory ;
              dcterms:identifier "WearBushing" .
 
 
 ###  https://w3id.org/energy-domain/edo#WearBushingRunningTool
-:WearBushingRunningTool rdf:type owl:Class ;
-                        rdfs:subClassOf :RunningTool ;
+edo:WearBushingRunningTool rdf:type owl:Class ;
+                        rdfs:subClassOf edo:RunningTool ;
                         dcterms:identifier "WearBushingRunningTool" .
 
 
 ###  https://w3id.org/energy-domain/edo#Wellhead
-:Wellhead rdf:type owl:Class ;
-          rdfs:subClassOf :Structure ;
+edo:Wellhead rdf:type owl:Class ;
+          rdfs:subClassOf edo:Structure ;
           dcterms:identifier "Wellhead" .
 
 
 ###  https://w3id.org/energy-domain/edo#WetChristmasTree
-:WetChristmasTree rdf:type owl:Class ;
-                  rdfs:subClassOf :FlowControlEquipment ;
+edo:WetChristmasTree rdf:type owl:Class ;
+                  rdfs:subClassOf edo:FlowControlEquipment ;
                   dcterms:identifier "WetChristmasTree" ;
-                  :ifc_objectType "WetChristmasTree" ;
-                  :ifc_predefinedType "USERDEFINED" .
+                  edo:ifc_objectType "WetChristmasTree" ;
+                  edo:ifc_predefinedType "USERDEFINED" .
 
 
 ###  https://w3id.org/energy-domain/edo#Wind
-:Wind rdf:type owl:Class ;
-      rdfs:subClassOf :Renewable ;
+edo:Wind rdf:type owl:Class ;
+      rdfs:subClassOf edo:Renewable ;
       rdfs:label "Energia Eólica"@pt-br ,
                  "Wind Energy"@en ;
       skos:definition "Energia gerada a partir do vento usando turbinas e tecnologias relacionadas."@pt-br ,
@@ -7041,8 +7040,8 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#WireLayer
-:WireLayer rdf:type owl:Class ;
-           rdfs:subClassOf :ArmourLayer ;
+edo:WireLayer rdf:type owl:Class ;
+           rdfs:subClassOf edo:ArmourLayer ;
            dcterms:identifier "WireLayer" ;
            skos:definition "Basis for all wired layers."@en ;
            skos:prefLabel "Camada de Arame"@pt-br ,
@@ -7050,67 +7049,67 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#WireRopeQuantity
-:WireRopeQuantity rdf:type owl:Class ;
-                  rdfs:subClassOf :DomainAttribute ;
+edo:WireRopeQuantity rdf:type owl:Class ;
+                  rdfs:subClassOf edo:DomainAttribute ;
                   dcterms:accessRights "PUBLIC" ;
                   dcterms:identifier "WireRopeQuantity" ;
                   skos:definition "Indicates the number of wire ropes required or used for installation or operation"@en ;
                   skos:prefLabel "Quantidade de cordas de Aço"@pt-br ,
                                  "Wire Rope Quantity"@en ;
-                  :hasAttributeScope :TypeLevelAttribute ;
-                  :hasTypedValue :intValue ;
-                  :hasValueCardinality :singleValue .
+                  edo:hasAttributeScope edo:TypeLevelAttribute ;
+                  edo:hasTypedValue edo:intValue ;
+                  edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#WireRopeSegment
-:WireRopeSegment rdf:type owl:Class ;
-                 rdfs:subClassOf :RopeSegment ;
+edo:WireRopeSegment rdf:type owl:Class ;
+                 rdfs:subClassOf edo:RopeSegment ;
                  dcterms:identifier "WireRopeSegment" .
 
 
 ###  https://w3id.org/energy-domain/edo#WireRopeSlingDiameter
-:WireRopeSlingDiameter rdf:type owl:Class ;
-                       rdfs:subClassOf :DomainAttribute ;
+edo:WireRopeSlingDiameter rdf:type owl:Class ;
+                       rdfs:subClassOf edo:DomainAttribute ;
                        dcterms:accessRights "PUBLIC" ;
                        dcterms:identifier "WireRopeSlingDiameter" ;
                        skos:definition "Diâmetro do Estrobo de Corda de Aço"@pt-br ,
                                        "Specifies the diameter of the wire rope sling. This property provides the measurement of the thickness of the wire rope, which is important for determining its strength and load-bearing capacity."@en ;
                        skos:prefLabel "Diâmetro do Estrobo de Corda de Aço"@pt-br ,
                                       "Wire Rope Sling Diameter"@en ;
-                       :hasAttributeScope :TypeLevelAttribute ;
-                       :hasTypedValue :floatValue ;
-                       :hasValueCardinality :singleValue .
+                       edo:hasAttributeScope edo:TypeLevelAttribute ;
+                       edo:hasTypedValue edo:floatValue ;
+                       edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#WireRopeSlingLength
-:WireRopeSlingLength rdf:type owl:Class ;
-                     rdfs:subClassOf :DomainAttribute ;
+edo:WireRopeSlingLength rdf:type owl:Class ;
+                     rdfs:subClassOf edo:DomainAttribute ;
                      dcterms:accessRights "PUBLIC" ;
                      dcterms:identifier "WireRopeSlingLength" ;
                      skos:definition "Specifies the length of the wire rope sling used in the installation or operation. This property provides the measurement of the sling’s length, which is essential for ensuring proper fit and functionality during use."@en ;
                      skos:prefLabel "Comprimento do Estrobo da Corda de Aço"@pt-br ,
                                     "Wire Rope Sling Length"@en ;
-                     :hasAttributeScope :TypeLevelAttribute ;
-                     :hasTypedValue :floatValue ;
-                     :hasValueCardinality :singleValue .
+                     edo:hasAttributeScope edo:TypeLevelAttribute ;
+                     edo:hasTypedValue edo:floatValue ;
+                     edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#WorkingLoadLimit
-:WorkingLoadLimit rdf:type owl:Class ;
-                  rdfs:subClassOf :DomainAttribute ;
+edo:WorkingLoadLimit rdf:type owl:Class ;
+                  rdfs:subClassOf edo:DomainAttribute ;
                   dcterms:accessRights "PUBLIC" ;
                   dcterms:identifier "WorkingLoadLimit" ;
                   skos:definition "The Working Load Limit (WLL) refers to the maximum load that a component, such as a shackle, lifting device, or anchor, is designed to safely support under normal operating conditions."@en ;
                   skos:prefLabel "Limite de Carga de Trabalho"@pt-br ,
                                  "Working Load Limit (WLL)"@en ;
-                  :hasAttributeScope :InstanceLevelAttribute ;
-                  :hasTypedValue :floatValue ;
-                  :hasValueCardinality :singleValue .
+                  edo:hasAttributeScope edo:InstanceLevelAttribute ;
+                  edo:hasTypedValue edo:floatValue ;
+                  edo:hasValueCardinality edo:singleValue .
 
 
 ###  https://w3id.org/energy-domain/edo#WoundLayer
-:WoundLayer rdf:type owl:Class ;
-            rdfs:subClassOf :FlexibleStructureLayer ;
+edo:WoundLayer rdf:type owl:Class ;
+            rdfs:subClassOf edo:FlexibleStructureLayer ;
             dcterms:identifier "WoundLayer" ;
             skos:definition "Basis for all layers constructed by helical winding of one or more elements."@en ;
             skos:prefLabel "Camada Espiralada"@pt-br ,
@@ -7118,147 +7117,147 @@ rdf:value rdf:type owl:DatatypeProperty .
 
 
 ###  https://w3id.org/energy-domain/edo#anyURIType
-:anyURIType rdf:type owl:Class ;
+edo:anyURIType rdf:type owl:Class ;
             owl:equivalentClass [ rdf:type owl:Restriction ;
                                   owl:onProperty rdf:value ;
                                   owl:allValuesFrom xsd:anyURI
                                 ] ;
-            rdfs:subClassOf :TypedValue ;
+            rdfs:subClassOf edo:TypedValue ;
             rdfs:comment "Constraint for xsd:anyURI (URIs/IRIs)"@en ;
             rdfs:label "URI Value"@en .
 
 
 ###  https://w3id.org/energy-domain/edo#base64BinaryType
-:base64BinaryType rdf:type owl:Class ;
+edo:base64BinaryType rdf:type owl:Class ;
                   owl:equivalentClass [ rdf:type owl:Restriction ;
                                         owl:onProperty rdf:value ;
                                         owl:allValuesFrom xsd:base64Binary
                                       ] ;
-                  rdfs:subClassOf :TypedValue ;
+                  rdfs:subClassOf edo:TypedValue ;
                   rdfs:comment "Constraint for xsd:base64Binary (binary data)"@en ;
                   rdfs:label "Base64 Binary"@en .
 
 
 ###  https://w3id.org/energy-domain/edo#booleanValue
-:booleanValue rdf:type owl:Class ;
+edo:booleanValue rdf:type owl:Class ;
               owl:equivalentClass [ rdf:type owl:Restriction ;
                                     owl:onProperty rdf:value ;
                                     owl:allValuesFrom xsd:boolean
                                   ] ;
-              rdfs:subClassOf :TypedValue ;
+              rdfs:subClassOf edo:TypedValue ;
               rdfs:comment "Constraint for xsd:boolean (true/false)"@en ;
               rdfs:label "Boolean Value"@en .
 
 
 ###  https://w3id.org/energy-domain/edo#dateTimeValue
-:dateTimeValue rdf:type owl:Class ;
+edo:dateTimeValue rdf:type owl:Class ;
                owl:equivalentClass [ rdf:type owl:Restriction ;
                                      owl:onProperty rdf:value ;
                                      owl:allValuesFrom xsd:dateTime
                                    ] ;
-               rdfs:subClassOf :TypedValue ;
+               rdfs:subClassOf edo:TypedValue ;
                rdfs:comment "Constraint for xsd:dateTime (timestamps)"@en ;
                rdfs:label "DateTime Value"@en .
 
 
 ###  https://w3id.org/energy-domain/edo#dateValue
-:dateValue rdf:type owl:Class ;
+edo:dateValue rdf:type owl:Class ;
            owl:equivalentClass [ rdf:type owl:Restriction ;
                                  owl:onProperty rdf:value ;
                                  owl:allValuesFrom xsd:date
                                ] ;
-           rdfs:subClassOf :TypedValue ;
+           rdfs:subClassOf edo:TypedValue ;
            rdfs:comment "Constraint for xsd:date (calendar dates)"@en ;
            rdfs:label "Date Value"@en .
 
 
 ###  https://w3id.org/energy-domain/edo#decimalValue
-:decimalValue rdf:type owl:Class ;
+edo:decimalValue rdf:type owl:Class ;
               owl:equivalentClass [ rdf:type owl:Restriction ;
                                     owl:onProperty rdf:value ;
                                     owl:allValuesFrom xsd:decimal
                                   ] ;
-              rdfs:subClassOf :TypedValue ;
+              rdfs:subClassOf edo:TypedValue ;
               rdfs:comment "Constraint for xsd:decimal (arbitrary precision numbers)"@en ;
               rdfs:label "Decimal Value"@en .
 
 
 ###  https://w3id.org/energy-domain/edo#doubleValue
-:doubleValue rdf:type owl:Class ;
+edo:doubleValue rdf:type owl:Class ;
              owl:equivalentClass [ rdf:type owl:Restriction ;
                                    owl:onProperty rdf:value ;
                                    owl:allValuesFrom xsd:double
                                  ] ;
-             rdfs:subClassOf :TypedValue ;
+             rdfs:subClassOf edo:TypedValue ;
              rdfs:comment "Constraint for xsd:double (64-bit floating point)"@en ;
              rdfs:label "Double Value"@en .
 
 
 ###  https://w3id.org/energy-domain/edo#floatValue
-:floatValue rdf:type owl:Class ;
+edo:floatValue rdf:type owl:Class ;
             owl:equivalentClass [ rdf:type owl:Restriction ;
                                   owl:onProperty rdf:value ;
                                   owl:allValuesFrom xsd:float
                                 ] ;
-            rdfs:subClassOf :TypedValue ;
+            rdfs:subClassOf edo:TypedValue ;
             rdfs:comment "Constraint for xsd:float (32-bit floating point)"@en ;
             rdfs:label "Float Value"@en .
 
 
 ###  https://w3id.org/energy-domain/edo#intValue
-:intValue rdf:type owl:Class ;
+edo:intValue rdf:type owl:Class ;
           owl:equivalentClass [ rdf:type owl:Restriction ;
                                 owl:onProperty rdf:value ;
                                 owl:allValuesFrom xsd:int
                               ] ;
-          rdfs:subClassOf :TypedValue ;
+          rdfs:subClassOf edo:TypedValue ;
           rdfs:comment "Constraint for xsd:int (32-bit integer)"@en ;
           rdfs:label "Integer Value"@en .
 
 
 ###  https://w3id.org/energy-domain/edo#longValue
-:longValue rdf:type owl:Class ;
+edo:longValue rdf:type owl:Class ;
            owl:equivalentClass [ rdf:type owl:Restriction ;
                                  owl:onProperty rdf:value ;
                                  owl:allValuesFrom xsd:long
                                ] ;
-           rdfs:subClassOf :TypedValue ;
+           rdfs:subClassOf edo:TypedValue ;
            rdfs:comment "Constraint for xsd:long (64-bit integer)"@en ;
            rdfs:label "Long Value"@en .
 
 
 ###  https://w3id.org/energy-domain/edo#multiValue
-:multiValue rdf:type owl:Class ;
-            rdfs:subClassOf :ValueCardinality ;
+edo:multiValue rdf:type owl:Class ;
+            rdfs:subClassOf edo:ValueCardinality ;
             rdfs:comment "Constraint allowing multiple values (RDF list)"@en ;
             rdfs:label "Multiple Values"@en .
 
 
 ###  https://w3id.org/energy-domain/edo#singleValue
-:singleValue rdf:type owl:Class ;
-             rdfs:subClassOf :ValueCardinality ;
+edo:singleValue rdf:type owl:Class ;
+             rdfs:subClassOf edo:ValueCardinality ;
              rdfs:comment "Constraint ensuring only one value (not a list)"@en ;
              rdfs:label "Single Value"@en .
 
 
 ###  https://w3id.org/energy-domain/edo#stringValue
-:stringValue rdf:type owl:Class ;
+edo:stringValue rdf:type owl:Class ;
              owl:equivalentClass [ rdf:type owl:Restriction ;
                                    owl:onProperty rdf:value ;
                                    owl:allValuesFrom xsd:string
                                  ] ;
-             rdfs:subClassOf :TypedValue ;
+             rdfs:subClassOf edo:TypedValue ;
              rdfs:comment "Constraint for xsd:string (character strings)"@en ;
              rdfs:label "String Value"@en .
 
 
 ###  https://w3id.org/energy-domain/edo#timeValue
-:timeValue rdf:type owl:Class ;
+edo:timeValue rdf:type owl:Class ;
            owl:equivalentClass [ rdf:type owl:Restriction ;
                                  owl:onProperty rdf:value ;
                                  owl:allValuesFrom xsd:time
                                ] ;
-           rdfs:subClassOf :TypedValue ;
+           rdfs:subClassOf edo:TypedValue ;
            rdfs:comment "Constraint for xsd:time (time of day)"@en ;
            rdfs:label "Time Value"@en .
 


### PR DESCRIPTION
Eliminei o prefixo inicial com só : 

E no resto da ontologia eu usei substituição automatica usando regex para substituir todos os : no inicio de linha (busquei por "^:" e substitui por "edo:").

Tambem busquei por " :" e substitui por " edo:".

Sera que em algum caso pode ter dado ruim? Abri no protege e abriu normal.